### PR TITLE
Switch to returning SemiFuture.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "0.2.0"
+    version = "0.3.0"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -29,9 +29,9 @@ struct PGInfo {
 class PGManager {
 public:
     virtual ~PGManager() = default;
-    virtual folly::Future< PGError > create_pg(PGInfo const& pg_info) = 0;
-    virtual folly::Future< PGError > replace_member(pg_id id, peer_id const& old_member,
-                                                    PGMember const& new_member) = 0;
+    virtual folly::SemiFuture< PGError > create_pg(PGInfo const& pg_info) = 0;
+    virtual folly::SemiFuture< PGError > replace_member(pg_id id, peer_id const& old_member,
+                                                        PGMember const& new_member) = 0;
 };
 
 inline bool operator<(homeobject::PGMember const& lhs, homeobject::PGMember const& rhs) { return lhs.id < rhs.id; }

--- a/src/include/homeobject/shard_manager.hpp
+++ b/src/include/homeobject/shard_manager.hpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <variant>
 
+#include <folly/futures/Future.h>
 #include <sisl/utility/enum.hpp>
 
 #include "common.hpp"
@@ -26,22 +27,26 @@ struct ShardInfo {
     uint64_t available_capacity_bytes;
     uint64_t total_capacity_bytes;
     uint64_t deleted_capacity_bytes;
+    std::optional< peer_id > current_leader{std::nullopt};
 };
 
 class ShardManager {
 public:
     // std::optional<peer_id> returned in case follower received request.
-    using info_cb = std::function< void(std::variant< ShardInfo, ShardError > const&, std::optional< peer_id >) >;
-    using list_cb =
-        std::function< void(std::variant< std::vector< ShardInfo >, ShardError > const&, std::optional< peer_id >) >;
+    using info_var = std::variant< ShardInfo, ShardError >;
+    using list_var = std::variant< std::vector< ShardInfo >, ShardError >;
 
     static uint64_t max_shard_size(); // Static function forces runtime evaluation.
 
     virtual ~ShardManager() = default;
-    virtual void create_shard(pg_id pg_owner, uint64_t size_bytes, info_cb const& cb) = 0;
-    virtual void get_shard(shard_id id, info_cb const& cb) const = 0;
-    virtual void list_shards(pg_id id, list_cb const& cb) const = 0;
-    virtual void seal_shard(shard_id id, info_cb const& cb) = 0;
+
+    // Sync
+    virtual info_var get_shard(shard_id id) const = 0;
+
+    // Async
+    virtual folly::SemiFuture< info_var > create_shard(pg_id pg_owner, uint64_t size_bytes) = 0;
+    virtual folly::SemiFuture< list_var > list_shards(pg_id id) const = 0;
+    virtual folly::SemiFuture< info_var > seal_shard(shard_id id) = 0;
 };
 
 } // namespace homeobject

--- a/src/lib/blob_manager.cpp
+++ b/src/lib/blob_manager.cpp
@@ -4,17 +4,17 @@ namespace homeobject {
 
 std::shared_ptr< BlobManager > HomeObjectImpl::blob_manager() { return shared_from_this(); }
 
-void HomeObjectImpl::put(shard_id shard, Blob&&, BlobManager::id_cb const& cb) {
-    cb(BlobError::UNKNOWN_SHARD, std::nullopt);
+folly::SemiFuture< std::variant< blob_id, BlobError > > HomeObjectImpl::put(shard_id shard, Blob&&) {
+    return folly::makeFuture(BlobError::UNKNOWN_SHARD);
 }
 
-void HomeObjectImpl::get(shard_id shard, blob_id const& blob, uint64_t off, uint64_t len,
-                         BlobManager::get_cb const& cb) const {
-    cb(BlobError::UNKNOWN_SHARD, std::nullopt);
+folly::SemiFuture< std::variant< Blob, BlobError > > HomeObjectImpl::get(shard_id shard, blob_id const& blob,
+                                                                         uint64_t off, uint64_t len) const {
+    return folly::makeFuture(BlobError::UNKNOWN_SHARD);
 }
 
-void HomeObjectImpl::del(shard_id shard, blob_id const& blob, BlobManager::ok_cb const& cb) {
-    cb(BlobError::UNKNOWN_SHARD, std::nullopt);
+folly::SemiFuture< BlobError > HomeObjectImpl::del(shard_id shard, blob_id const& blob) {
+    return folly::makeFuture(BlobError::UNKNOWN_SHARD);
 }
 
 } // namespace homeobject

--- a/src/lib/homeobject_impl.hpp
+++ b/src/lib/homeobject_impl.hpp
@@ -27,20 +27,21 @@ public:
     std::shared_ptr< ShardManager > shard_manager() override;
 
     /// PgManager
-    folly::Future< PGError > create_pg(PGInfo const& pg_info) override;
-    folly::Future< PGError > replace_member(pg_id id, peer_id const& old_member, PGMember const& new_member) override;
+    folly::SemiFuture< PGError > create_pg(PGInfo const& pg_info) override;
+    folly::SemiFuture< PGError > replace_member(pg_id id, peer_id const& old_member,
+                                                PGMember const& new_member) override;
 
     /// ShardManager
-    void create_shard(pg_id pg_owner, uint64_t size_bytes, ShardManager::info_cb const& cb) override;
-    void list_shards(pg_id pg, ShardManager::list_cb const& cb) const override;
-    void get_shard(shard_id id, ShardManager::info_cb const& cb) const override;
-    void seal_shard(shard_id id, ShardManager::info_cb const& cb) override;
+    ShardManager::info_var get_shard(shard_id id) const override;
+    folly::SemiFuture< ShardManager::info_var > create_shard(pg_id pg_owner, uint64_t size_bytes) override;
+    folly::SemiFuture< ShardManager::list_var > list_shards(pg_id pg) const override;
+    folly::SemiFuture< ShardManager::info_var > seal_shard(shard_id id) override;
 
     /// BlobManager
-    void put(shard_id shard, Blob&&, BlobManager::id_cb const& cb) override;
-    void get(shard_id shard, blob_id const& blob, uint64_t off, uint64_t len,
-             BlobManager::get_cb const& cb) const override;
-    void del(shard_id shard, blob_id const& blob, BlobManager::ok_cb const& cb) override;
+    folly::SemiFuture< std::variant< blob_id, BlobError > > put(shard_id shard, Blob&&) override;
+    folly::SemiFuture< std::variant< Blob, BlobError > > get(shard_id shard, blob_id const& blob, uint64_t off,
+                                                             uint64_t len) const override;
+    folly::SemiFuture< BlobError > del(shard_id shard, blob_id const& blob) override;
 };
 
 } // namespace homeobject

--- a/src/lib/pg_manager.cpp
+++ b/src/lib/pg_manager.cpp
@@ -4,13 +4,13 @@ namespace homeobject {
 
 std::shared_ptr< PGManager > HomeObjectImpl::pg_manager() { return shared_from_this(); }
 
-folly::Future< PGError > HomeObjectImpl::create_pg(PGInfo const& pg_info) {
-    return folly::makeFuture< PGError >(PGError::TIMEOUT);
+folly::SemiFuture< PGError > HomeObjectImpl::create_pg(PGInfo const& pg_info) {
+    return folly::makeFuture(PGError::TIMEOUT);
 }
 
-folly::Future< PGError > HomeObjectImpl::replace_member(pg_id id, peer_id const& old_member,
-                                                        PGMember const& new_member) {
-    return folly::makeFuture< PGError >(PGError::UNKNOWN_PG);
+folly::SemiFuture< PGError > HomeObjectImpl::replace_member(pg_id id, peer_id const& old_member,
+                                                            PGMember const& new_member) {
+    return folly::makeFuture(PGError::UNKNOWN_PG);
 }
 
 } // namespace homeobject

--- a/src/lib/shard_manager.cpp
+++ b/src/lib/shard_manager.cpp
@@ -11,23 +11,19 @@ std::shared_ptr< HomeObject > init_homeobject(init_params const& params) {
     return std::make_shared< HomeObjectImpl >(params.lookup);
 }
 
-void HomeObjectImpl::create_shard(pg_id pg_owner, uint64_t size_bytes, ShardManager::info_cb const& cb) {
-    if (0 == size_bytes || max_shard_size() < size_bytes)
-        cb(ShardError::INVALID_ARG, std::nullopt);
-    else
-        cb(ShardError::UNKNOWN_PG, std::nullopt);
+folly::SemiFuture< ShardManager::info_var > HomeObjectImpl::create_shard(pg_id pg_owner, uint64_t size_bytes) {
+    if (0 == size_bytes || max_shard_size() < size_bytes) return folly::makeFuture(ShardError::INVALID_ARG);
+    return folly::makeFuture(ShardError::UNKNOWN_PG);
 }
 
-void HomeObjectImpl::list_shards(pg_id pg, ShardManager::list_cb const& cb) const {
-    cb(ShardError::UNKNOWN_PG, std::nullopt);
+folly::SemiFuture< ShardManager::list_var > HomeObjectImpl::list_shards(pg_id pg) const {
+    return folly::makeFuture(ShardError::UNKNOWN_PG);
 }
 
-void HomeObjectImpl::get_shard(shard_id id, ShardManager::info_cb const& cb) const {
-    cb(ShardError::UNKNOWN_SHARD, std::nullopt);
-}
+ShardManager::info_var HomeObjectImpl::get_shard(shard_id id) const { return ShardError::UNKNOWN_SHARD; }
 
-void HomeObjectImpl::seal_shard(shard_id id, ShardManager::info_cb const& cb) {
-    cb(ShardError::UNKNOWN_SHARD, std::nullopt);
+folly::SemiFuture< ShardManager::info_var > HomeObjectImpl::seal_shard(shard_id id) {
+    return folly::makeFuture(ShardError::UNKNOWN_SHARD);
 }
 
 } // namespace homeobject

--- a/src/mocks/mock_blob_manager.cpp
+++ b/src/mocks/mock_blob_manager.cpp
@@ -4,66 +4,72 @@ namespace homeobject {
 using namespace std::chrono_literals;
 constexpr auto disk_latency = 15ms;
 
-#define WITH_DATA_LOCKS(e)                                                                                             \
-    auto err = (e);                                                                                                    \
-    {                                                                                                                  \
-        auto lg = std::scoped_lock(_shard_lock, _data_lock);
-
-#define CB_FROM_DATA_LOCKS(ret)                                                                                        \
-    }                                                                                                                  \
-    CB_IF_DEFINED(ret, err, BlobError::OK)
-
-void MockHomeObject::put(shard_id shard, Blob&& blob, BlobManager::id_cb const& cb) {
-    std::thread([this, shard, mblob = std::move(blob), cb = std::move(cb)]() mutable {
+folly::SemiFuture< std::variant< blob_id, BlobError > > MockHomeObject::put(shard_id shard, Blob&& blob) {
+    auto [p, f] = folly::makePromiseContract< std::variant< blob_id, BlobError > >();
+    std::thread([this, shard, mblob = std::move(blob), p = std::move(p)]() mutable {
         std::this_thread::sleep_for(disk_latency);
         blob_id id;
-        WITH_DATA_LOCKS(BlobError::UNKNOWN_SHARD)
-        if (0 != _shards.count(shard)) {
-            err = BlobError::OK;
-            id = _cur_blob_id;
-            if (auto [_, happened] = _in_memory_disk.try_emplace(BlobRoute{shard, id}, std::move(mblob)); happened) {
-                _cur_blob_id++;
+        auto err = BlobError::UNKNOWN_SHARD;
+        {
+            auto lg = std::scoped_lock(_shard_lock, _data_lock);
+            if (0 != _shards.count(shard)) {
+                err = BlobError::OK;
+                id = _cur_blob_id;
+                if (auto [_, happened] = _in_memory_disk.try_emplace(BlobRoute{shard, id}, std::move(mblob));
+                    happened) {
+                    _cur_blob_id++;
+                }
             }
         }
-        CB_FROM_DATA_LOCKS(id)
+        (BlobError::OK == err) ? p.setValue(id) : p.setValue(err);
     }).detach();
+    return f;
 }
 
-void MockHomeObject::get(shard_id shard, blob_id const& id, uint64_t, uint64_t, BlobManager::get_cb const& cb) const {
-    std::thread([this, shard, id, cb = std::move(cb)]() {
-        BlobError serr = BlobError::UNKNOWN_SHARD;
+folly::SemiFuture< std::variant< Blob, BlobError > > MockHomeObject::get(shard_id shard, blob_id const& id, uint64_t,
+                                                                         uint64_t) const {
+    auto [p, f] = folly::makePromiseContract< std::variant< Blob, BlobError > >();
+    std::thread([this, shard, id, p = std::move(p)]() mutable {
         // Only need to lookup shard with _shard_lock for READs, okay to seal while reading
         {
             auto lg = std::scoped_lock(_shard_lock);
-            if (auto const it = _shards.find(shard); it != _shards.end()) { serr = BlobError::OK; }
+            LOGDEBUG("Looking up shard {} in set of {}", shard, _shards.size());
+            if (0 == _shards.count(shard)) p.setValue(BlobError::UNKNOWN_SHARD);
         }
-        if (BlobError::OK != serr) {
-            CB_IF_DEFINED(serr, serr, BlobError::OK)
-            return;
-        }
+        if (p.isFulfilled()) return;
 
         std::this_thread::sleep_for(disk_latency);
         Blob blob;
-        WITH_DATA_LOCKS(BlobError::UNKNOWN_BLOB)
-        if (auto it = _in_memory_disk.find(BlobRoute{shard, id}); it != _in_memory_disk.end()) {
-            auto const& read_blob = it->second;
-            blob.body = std::make_unique< sisl::byte_array_impl >(read_blob.body->size);
-            blob.object_off = read_blob.object_off;
-            blob.user_key = read_blob.user_key;
-            std::memcpy(blob.body->bytes, read_blob.body->bytes, blob.body->size);
-            err = BlobError::OK;
+        {
+            auto lg = std::scoped_lock(_shard_lock, _data_lock);
+            LOGDEBUG("Looking up Blob {} in set of {}", id, _in_memory_disk.size());
+            if (auto it = _in_memory_disk.find(BlobRoute{shard, id}); it != _in_memory_disk.end()) {
+                auto const& read_blob = it->second;
+                blob.body = std::make_unique< sisl::byte_array_impl >(read_blob.body->size);
+                blob.object_off = read_blob.object_off;
+                blob.user_key = read_blob.user_key;
+                std::memcpy(blob.body->bytes, read_blob.body->bytes, blob.body->size);
+                p.setValue(std::move(blob));
+            }
         }
-        CB_FROM_DATA_LOCKS(std::move(blob))
+        if (!p.isFulfilled()) p.setValue(BlobError::UNKNOWN_BLOB);
     }).detach();
+    return f;
 }
-void MockHomeObject::del(shard_id shard, blob_id const& blob, BlobManager::ok_cb const& cb) {
-    std::thread([this, shard, blob, cb = std::move(cb)]() {
-        WITH_DATA_LOCKS(BlobError::UNKNOWN_SHARD)
-        if (auto const it = _shards.find(shard); it != _shards.end()) {
-            err = (0 < _in_memory_disk.erase(BlobRoute{shard, blob})) ? BlobError::OK : BlobError::UNKNOWN_BLOB;
+
+folly::SemiFuture< BlobError > MockHomeObject::del(shard_id shard, blob_id const& blob) {
+    auto [p, f] = folly::makePromiseContract< BlobError >();
+    std::thread([this, shard, blob, p = std::move(p)]() mutable {
+        auto err = BlobError::UNKNOWN_SHARD;
+        {
+            auto lg = std::scoped_lock(_shard_lock, _data_lock);
+            if (auto const it = _shards.find(shard); it != _shards.end()) {
+                err = (0 < _in_memory_disk.erase(BlobRoute{shard, blob})) ? BlobError::OK : BlobError::UNKNOWN_BLOB;
+            }
         }
-        CB_FROM_DATA_LOCKS(err)
+        p.setValue(err);
     }).detach();
+    return f;
 }
 
 } // namespace homeobject

--- a/src/mocks/mock_homeobject.hpp
+++ b/src/mocks/mock_homeobject.hpp
@@ -11,15 +11,6 @@
 #include <homeobject/pg_manager.hpp>
 #include <homeobject/shard_manager.hpp>
 
-#define CB_IF_DEFINED(ret, e, ok)                                                                                      \
-    if (!cb) return;                                                                                                   \
-    auto const temp_err = (e);                                                                                         \
-    if (temp_err == (ok)) {                                                                                            \
-        cb((ret), std::nullopt);                                                                                       \
-    } else {                                                                                                           \
-        cb(temp_err, std::nullopt);                                                                                    \
-    }
-
 namespace homeobject {
 struct BlobRoute {
     shard_id shard;
@@ -73,20 +64,21 @@ public:
     std::shared_ptr< ShardManager > shard_manager() override { return shared_from_this(); }
 
     // BlobManager
-    void put(shard_id shard, Blob&&, BlobManager::id_cb const& cb) override;
-    void get(shard_id shard, blob_id const& blob, uint64_t off, uint64_t len,
-             BlobManager::get_cb const& cb) const override;
-    void del(shard_id shard, blob_id const& blob, BlobManager::ok_cb const& cb) override;
+    folly::SemiFuture< std::variant< blob_id, BlobError > > put(shard_id shard, Blob&&) override;
+    folly::SemiFuture< std::variant< Blob, BlobError > > get(shard_id shard, blob_id const& blob, uint64_t off,
+                                                             uint64_t len) const override;
+    folly::SemiFuture< BlobError > del(shard_id shard, blob_id const& blob) override;
 
     // PGManager
-    folly::Future< PGError > create_pg(PGInfo const& pg_info) override;
-    folly::Future< PGError > replace_member(pg_id id, peer_id const& old_member, PGMember const& new_member) override;
+    folly::SemiFuture< PGError > create_pg(PGInfo const& pg_info) override;
+    folly::SemiFuture< PGError > replace_member(pg_id id, peer_id const& old_member,
+                                                PGMember const& new_member) override;
 
     // ShardManager
-    void create_shard(pg_id pg_owner, uint64_t size_bytes, ShardManager::info_cb const& cb) override;
-    void get_shard(shard_id id, ShardManager::info_cb const& cb) const override;
-    void list_shards(pg_id id, ShardManager::list_cb const& cb) const override;
-    void seal_shard(shard_id id, ShardManager::info_cb const& cb) override;
+    folly::SemiFuture< ShardManager::info_var > create_shard(pg_id pg_owner, uint64_t size_bytes) override;
+    ShardManager::info_var get_shard(shard_id id) const override;
+    folly::SemiFuture< ShardManager::list_var > list_shards(pg_id id) const override;
+    folly::SemiFuture< ShardManager::info_var > seal_shard(shard_id id) override;
 };
 
 } // namespace homeobject

--- a/src/mocks/mock_pg_manager.cpp
+++ b/src/mocks/mock_pg_manager.cpp
@@ -9,16 +9,16 @@
 
 #define RET_FOM_LOCK                                                                                                   \
     }                                                                                                                  \
-    return folly::makeFuture< PGError >(std::move(err));
+    return folly::makeFuture(std::move(err));
 
 namespace homeobject {
 
-folly::Future< PGError > MockHomeObject::create_pg(PGInfo const& pg_info) {
+folly::SemiFuture< PGError > MockHomeObject::create_pg(PGInfo const& pg_info) {
     LOGINFO("Creating PG: [{}] of [{}] members", pg_info.id, pg_info.members.size());
     if (std::none_of(pg_info.members.begin(), pg_info.members.end(),
                      [](PGMember const& m) { return 0 < m.priority; })) {
         LOGERROR("No possible leader for PG: [{}]", pg_info.id);
-        return folly::makeFuture< PGError >(PGError::INVALID_ARG);
+        return folly::makeFuture(PGError::INVALID_ARG);
     }
     WITH_PG_LOCK(PGError::INVALID_ARG)
     if (auto [_, happened] = _pg_map.try_emplace(pg_info.id, pg_info, std::unordered_set< shard_id >()); happened)
@@ -28,12 +28,12 @@ folly::Future< PGError > MockHomeObject::create_pg(PGInfo const& pg_info) {
     RET_FOM_LOCK
 }
 
-folly::Future< PGError > MockHomeObject::replace_member(pg_id id, peer_id const& old_member,
-                                                        PGMember const& new_member) {
+folly::SemiFuture< PGError > MockHomeObject::replace_member(pg_id id, peer_id const& old_member,
+                                                            PGMember const& new_member) {
     LOGINFO("Replacing PG: [{}] member [{}] with [{}]", id, to_string(old_member), to_string(new_member.id));
     if (old_member == new_member.id) {
         LOGWARN("Rejecting replace_member with identical replacement SvcId [{}]!", to_string(old_member));
-        return folly::makeFuture< PGError >(PGError::INVALID_ARG);
+        return folly::makeFuture(PGError::INVALID_ARG);
     }
     WITH_PG_LOCK(PGError::UNKNOWN_PG)
     if (auto pg_it = _pg_map.find(id); _pg_map.end() != pg_it) {

--- a/src/mocks/mock_shard_manager.cpp
+++ b/src/mocks/mock_shard_manager.cpp
@@ -8,67 +8,68 @@ static uint64_t get_current_timestamp() {
     return timestamp;
 }
 
-#define WITH_SHARD_LOCKS(e)                                                                                            \
-    auto err = (e);                                                                                                    \
-    {                                                                                                                  \
-        auto lg = std::scoped_lock(_pg_lock, _shard_lock);
-
-#define CB_FROM_SHARD_LOCKS(ret)                                                                                       \
-    }                                                                                                                  \
-    CB_IF_DEFINED(ret, err, ShardError::OK)
-
 uint64_t ShardManager::max_shard_size() { return Gi; }
 
-void MockHomeObject::create_shard(pg_id pg_owner, uint64_t size_bytes, ShardManager::info_cb const& cb) {
-    if (0 == size_bytes || max_shard_size() < size_bytes) {
-        if (cb) cb(ShardError::INVALID_ARG, std::nullopt);
-        return;
-    }
-    auto const now = get_current_timestamp();
-    auto ret = ShardInfo{0u, pg_owner, ShardInfo::State::OPEN, now, now, size_bytes, size_bytes, 0};
-    WITH_SHARD_LOCKS(ShardError::UNKNOWN_PG);
-    if (auto pg_it = _pg_map.find(pg_owner); _pg_map.end() != pg_it) {
-        ret.id = _cur_shard_id++;
-        LOGINFO("Creating Shard [{}]: in Pg [{}] of Size [{}b]", ret.id, pg_owner, size_bytes);
-        pg_it->second.second.emplace(ret.id);
-        err = _shards.try_emplace(ret.id, ret).second ? ShardError::OK : ShardError::UNKNOWN;
-    }
-    CB_FROM_SHARD_LOCKS(ret)
+folly::SemiFuture< ShardManager::info_var > MockHomeObject::create_shard(pg_id pg_owner, uint64_t size_bytes) {
+    if (0 == size_bytes || max_shard_size() < size_bytes) return folly::makeFuture(ShardError::INVALID_ARG);
+
+    auto [p, f] = folly::makePromiseContract< ShardManager::info_var >();
+    std::thread([this, pg_owner, size_bytes, p = std::move(p)]() mutable {
+        auto lg = std::scoped_lock(_pg_lock, _shard_lock);
+        if (auto pg_it = _pg_map.find(pg_owner); _pg_map.end() != pg_it) {
+            auto const now = get_current_timestamp();
+            auto info =
+                ShardInfo{_cur_shard_id++, pg_owner, ShardInfo::State::OPEN, now, now, size_bytes, size_bytes, 0};
+            pg_it->second.second.emplace(info.id);
+            LOGDEBUG("Creating Shard [{}]: in Pg [{}] of Size [{}b] shard_cnt:[{}]", info.id, pg_owner, size_bytes,
+                     _shards.size());
+            if (!_shards.try_emplace(info.id, info).second)
+                p.setValue(ShardError::UNKNOWN);
+            else
+                p.setValue(std::move(info));
+        } else
+            p.setValue(ShardError::UNKNOWN_PG);
+    }).detach();
+    return f;
 }
 
-void MockHomeObject::get_shard(shard_id id, ShardManager::info_cb const& cb) const {
-    auto info = ShardInfo();
-    WITH_SHARD_LOCKS(ShardError::UNKNOWN_SHARD)
-    if (auto shard_it = _shards.find(id); _shards.end() != shard_it) {
-        info = shard_it->second;
-        err = ShardError::OK;
-    }
-    CB_FROM_SHARD_LOCKS(info)
+ShardManager::info_var MockHomeObject::get_shard(shard_id id) const {
+    auto lg = std::scoped_lock(_pg_lock, _shard_lock);
+    if (auto shard_it = _shards.find(id); _shards.end() != shard_it) return shard_it->second;
+    return ShardError::UNKNOWN_SHARD;
 }
 
-void MockHomeObject::list_shards(pg_id id, ShardManager::list_cb const& cb) const {
-    auto info = std::vector< ShardInfo >();
-    WITH_SHARD_LOCKS(ShardError::UNKNOWN_PG)
-    if (auto pg_it = _pg_map.find(id); _pg_map.end() != pg_it) {
-        err = ShardError::OK;
-        for (auto const& shard_id : pg_it->second.second) {
-            auto shard_it = _shards.find(shard_id);
-            RELEASE_ASSERT(_shards.end() != shard_it, "Missing Shard [{}]!", shard_id);
-            info.push_back(shard_it->second);
-        }
-    }
-    CB_FROM_SHARD_LOCKS(info)
+folly::SemiFuture< ShardManager::list_var > MockHomeObject::list_shards(pg_id id) const {
+    auto [p, f] = folly::makePromiseContract< ShardManager::list_var >();
+    std::thread([this, id, p = std::move(p)]() mutable {
+        auto lg = std::scoped_lock(_pg_lock, _shard_lock);
+        if (auto pg_it = _pg_map.find(id); _pg_map.end() != pg_it) {
+            auto info = std::vector< ShardInfo >();
+            for (auto const& shard_id : pg_it->second.second) {
+                LOGDEBUG("Listing Shard {}", shard_id);
+                auto shard_it = _shards.find(shard_id);
+                RELEASE_ASSERT(_shards.end() != shard_it, "Missing Shard [{}]!", shard_id);
+                info.push_back(shard_it->second);
+            }
+            p.setValue(std::move(info));
+        } else
+            p.setValue(ShardError::UNKNOWN_PG);
+    }).detach();
+    return f;
 }
 
-void MockHomeObject::seal_shard(shard_id id, ShardManager::info_cb const& cb) {
-    auto info = ShardInfo();
-    WITH_SHARD_LOCKS(ShardError::UNKNOWN_SHARD)
-    if (auto shard_it = _shards.find(id); _shards.end() != shard_it) {
-        shard_it->second.state = ShardInfo::State::SEALED;
-        info = shard_it->second;
-        err = ShardError::OK;
-    }
-    CB_FROM_SHARD_LOCKS(info)
+folly::SemiFuture< ShardManager::info_var > MockHomeObject::seal_shard(shard_id id) {
+    auto [p, f] = folly::makePromiseContract< ShardManager::info_var >();
+    std::thread([this, id, p = std::move(p)]() mutable {
+        auto lg = std::scoped_lock(_pg_lock, _shard_lock);
+        if (auto shard_it = _shards.find(id); _shards.end() != shard_it) {
+            shard_it->second.state = ShardInfo::State::SEALED;
+            auto info = shard_it->second;
+            p.setValue(std::move(info));
+        } else
+            p.setValue(ShardError::UNKNOWN_SHARD);
+    }).detach();
+    return f;
 }
 
 } // namespace homeobject

--- a/src/mocks/tests/ShardManagerTest.cpp
+++ b/src/mocks/tests/ShardManagerTest.cpp
@@ -36,8 +36,8 @@ public:
         auto info = homeobject::PGInfo(_pg_id);
         info.members.insert(homeobject::PGMember{_peer1, "peer1", 1});
         info.members.insert(homeobject::PGMember{_peer2, "peer2", 0});
-        m_mock_homeobj->pg_manager()->create_pg(info).thenValue(
-            [](homeobject::PGError e) { EXPECT_EQ(homeobject::PGError::OK, e); });
+        auto e = m_mock_homeobj->pg_manager()->create_pg(info).get();
+        EXPECT_EQ(homeobject::PGError::OK, e);
     }
 
 protected:
@@ -45,28 +45,22 @@ protected:
 };
 
 TEST_F(ShardManagerFixture, CreateShardTooBig) {
-    m_mock_homeobj->shard_manager()->create_shard(
-        _pg_id, homeobject::ShardManager::max_shard_size() + 1,
-        [](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-            EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
-        });
+    auto v =
+        m_mock_homeobj->shard_manager()->create_shard(_pg_id, homeobject::ShardManager::max_shard_size() + 1).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
 }
 
 TEST_F(ShardManagerFixture, CreateShardTooSmall) {
-    m_mock_homeobj->shard_manager()->create_shard(
-        _pg_id, 0ul, [](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-            EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
-        });
+    auto v = m_mock_homeobj->shard_manager()->create_shard(_pg_id, 0ul).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
 }
 
 TEST_F(ShardManagerFixture, CreateShardNoPg) {
-    m_mock_homeobj->shard_manager()->create_shard(
-        _pg_id + 1, Mi, [](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-            EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
-        });
+    auto v = m_mock_homeobj->shard_manager()->create_shard(_pg_id + 1, Mi).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
 }
 
 class ShardManagerFixtureWShard : public ShardManagerFixture {
@@ -74,78 +68,61 @@ public:
     ShardInfo _shard;
     void SetUp() override {
         ShardManagerFixture::SetUp();
-        m_mock_homeobj->shard_manager()->create_shard(
-            _pg_id, Mi,
-            [this](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) mutable {
-                ASSERT_TRUE(std::holds_alternative< ShardInfo >(v));
-                _shard = std::get< ShardInfo >(v);
-                EXPECT_EQ(ShardInfo::State::OPEN, _shard.state);
-                EXPECT_EQ(Mi, _shard.total_capacity_bytes);
-                EXPECT_EQ(Mi, _shard.available_capacity_bytes);
-                EXPECT_EQ(0ul, _shard.deleted_capacity_bytes);
-                EXPECT_EQ(_pg_id, _shard.placement_group);
-            });
+        auto v = m_mock_homeobj->shard_manager()->create_shard(_pg_id, Mi).get();
+        ASSERT_TRUE(std::holds_alternative< ShardInfo >(v));
+        _shard = std::get< ShardInfo >(v);
+        EXPECT_EQ(ShardInfo::State::OPEN, _shard.state);
+        EXPECT_EQ(Mi, _shard.total_capacity_bytes);
+        EXPECT_EQ(Mi, _shard.available_capacity_bytes);
+        EXPECT_EQ(0ul, _shard.deleted_capacity_bytes);
+        EXPECT_EQ(_pg_id, _shard.placement_group);
     }
 };
 
 TEST_F(ShardManagerFixtureWShard, GetUnknownShard) {
-    m_mock_homeobj->shard_manager()->get_shard(
-        _shard.id + 1, [](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-            EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
-        });
+    auto v = m_mock_homeobj->shard_manager()->get_shard(_shard.id + 1);
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
 }
 
 TEST_F(ShardManagerFixtureWShard, GetKnownShard) {
-    m_mock_homeobj->shard_manager()->get_shard(
-        _shard.id, [this](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardInfo >(v));
-            auto const& info = std::get< ShardInfo >(v);
-            EXPECT_TRUE(info.id == _shard.id);
-            EXPECT_TRUE(info.placement_group == _shard.placement_group);
-            EXPECT_EQ(info.state, ShardInfo::State::OPEN);
-        });
+    auto v = m_mock_homeobj->shard_manager()->get_shard(_shard.id);
+    ASSERT_TRUE(std::holds_alternative< ShardInfo >(v));
+    auto const& info = std::get< ShardInfo >(v);
+    EXPECT_TRUE(info.id == _shard.id);
+    EXPECT_TRUE(info.placement_group == _shard.placement_group);
+    EXPECT_EQ(info.state, ShardInfo::State::OPEN);
 }
 
 TEST_F(ShardManagerFixtureWShard, ListShardsNoPg) {
-    m_mock_homeobj->shard_manager()->list_shards(
-        _pg_id + 1,
-        [this](std::variant< std::vector< ShardInfo >, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-            EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
-        });
+    auto v = m_mock_homeobj->shard_manager()->list_shards(_pg_id + 1).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
 }
 
 TEST_F(ShardManagerFixtureWShard, ListShards) {
-    m_mock_homeobj->shard_manager()->list_shards(
-        _pg_id,
-        [this](std::variant< std::vector< ShardInfo >, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< std::vector< ShardInfo > >(v));
-            auto const& info_vec = std::get< std::vector< ShardInfo > >(v);
-            EXPECT_EQ(info_vec.size(), 1);
-            EXPECT_TRUE(info_vec.begin()->id == _shard.id);
-            EXPECT_TRUE(info_vec.begin()->placement_group == _shard.placement_group);
-            EXPECT_EQ(info_vec.begin()->state, ShardInfo::State::OPEN);
-        });
+    auto v = m_mock_homeobj->shard_manager()->list_shards(_pg_id).get();
+    ASSERT_TRUE(std::holds_alternative< std::vector< ShardInfo > >(v));
+    auto const& info_vec = std::get< std::vector< ShardInfo > >(v);
+    ASSERT_EQ(info_vec.size(), 1);
+    EXPECT_TRUE(info_vec.begin()->id == _shard.id);
+    EXPECT_TRUE(info_vec.begin()->placement_group == _shard.placement_group);
+    EXPECT_EQ(info_vec.begin()->state, ShardInfo::State::OPEN);
 }
 
 TEST_F(ShardManagerFixtureWShard, SealShardNoShard) {
-    m_mock_homeobj->shard_manager()->seal_shard(
-        _shard.id + 1, [this](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-            EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
-        });
+    auto v = m_mock_homeobj->shard_manager()->seal_shard(_shard.id + 1).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
 }
 
 TEST_F(ShardManagerFixtureWShard, SealShard) {
-    m_mock_homeobj->shard_manager()->seal_shard(
-        _shard.id, [this](std::variant< ShardInfo, ShardError > const& v, std::optional< homeobject::peer_id >) {
-            ASSERT_TRUE(std::holds_alternative< ShardInfo >(v));
-            auto const& info = std::get< ShardInfo >(v);
-            EXPECT_TRUE(info.id == _shard.id);
-            EXPECT_TRUE(info.placement_group == _shard.placement_group);
-            EXPECT_EQ(info.state, ShardInfo::State::SEALED);
-        });
+    auto v = m_mock_homeobj->shard_manager()->seal_shard(_shard.id).get();
+    ASSERT_TRUE(std::holds_alternative< ShardInfo >(v));
+    auto const& info = std::get< ShardInfo >(v);
+    EXPECT_TRUE(info.id == _shard.id);
+    EXPECT_TRUE(info.placement_group == _shard.placement_group);
+    EXPECT_EQ(info.state, ShardInfo::State::SEALED);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/tests/test_home_object.cpp
+++ b/src/tests/test_home_object.cpp
@@ -35,125 +35,82 @@ TEST(HomeObject, BasicEquivalence) {
 }
 
 class HomeObjectFixture : public ::testing::Test {
-    struct call_tracker {
-        std::mutex call_lock;
-        std::condition_variable call_cond;
-        bool called{false};
-
-        void signal() {
-            auto lg = std::scoped_lock< std::mutex >(call_lock);
-            called = true;
-            call_cond.notify_all();
-        }
-
-        bool wait(auto const& dur) {
-            auto lg = std::unique_lock< std::mutex >(call_lock);
-            return call_cond.wait_for(lg, dur, [this] { return called; });
-        }
-    };
-
 public:
-    call_tracker _t;
     std::shared_ptr< homeobject::HomeObject > _obj_inst;
 
     void SetUp() override {
         _obj_inst = homeobject::init_homeobject(
             homeobject::init_params{[](homeobject::peer_id const&) -> std::string { return "test_fixture"; }});
     }
-    void TearDown() override { EXPECT_TRUE(_t.wait(100ms)); }
 };
 
 // TODO: This test should actually not fail assuming initialization succeeded,
 // but until it is implemented we will just assume the RAFT group was
 // unresponsive and timed-out.
 TEST_F(HomeObjectFixture, CreatePgTimeout) {
-    _obj_inst->pg_manager()->create_pg(homeobject::PGInfo{0l}).thenValue([this](auto const& e) {
-        EXPECT_EQ(e, PGError::TIMEOUT);
-        _t.signal();
-    });
+    EXPECT_EQ(_obj_inst->pg_manager()->create_pg(homeobject::PGInfo{0l}).get(), PGError::TIMEOUT);
 }
 
 TEST_F(HomeObjectFixture, ReplaceMemberMissingPg) {
-    _obj_inst->pg_manager()
-        ->replace_member(0, boost::uuids::random_generator()(),
-                         homeobject::PGMember{boost::uuids::random_generator()(), "new_member", 1})
-        .thenValue([this](auto const& e) {
-            EXPECT_EQ(e, PGError::UNKNOWN_PG);
-            _t.signal();
-        });
+    EXPECT_EQ(_obj_inst->pg_manager()
+                  ->replace_member(0, boost::uuids::random_generator()(),
+                                   homeobject::PGMember{boost::uuids::random_generator()(), "new_member", 1})
+                  .get(),
+              PGError::UNKNOWN_PG);
 }
 
 TEST_F(HomeObjectFixture, CreateShardMissingPg) {
-    _obj_inst->shard_manager()->create_shard(1, 1000, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-        EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
-        _t.signal();
-    });
+    auto v = _obj_inst->shard_manager()->create_shard(1, 1000).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
 }
 
 TEST_F(HomeObjectFixture, CreateShardZeroSize) {
-    _obj_inst->shard_manager()->create_shard(1, 0, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-        EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
-        _t.signal();
-    });
+    auto v = _obj_inst->shard_manager()->create_shard(1, 0).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
 }
 
 TEST_F(HomeObjectFixture, CreateShardTooBig) {
-    _obj_inst->shard_manager()->create_shard(1, 2 * Gi, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-        EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
-        _t.signal();
-    });
+    auto v = _obj_inst->shard_manager()->create_shard(1, 2 * Gi).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::INVALID_ARG);
 }
 
 TEST_F(HomeObjectFixture, ListShardsUnknownPg) {
-    _obj_inst->shard_manager()->list_shards(1, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-        EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
-        _t.signal();
-    });
+    auto v = _obj_inst->shard_manager()->list_shards(1).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_PG);
 }
 
 TEST_F(HomeObjectFixture, GetUnknownShard) {
-    _obj_inst->shard_manager()->get_shard(1, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-        EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
-        _t.signal();
-    });
+    auto v = _obj_inst->shard_manager()->get_shard(1);
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
 }
 
 TEST_F(HomeObjectFixture, SealUnknownShard) {
-    _obj_inst->shard_manager()->seal_shard(1, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< ShardError >(v));
-        EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
-        _t.signal();
-    });
+    auto v = _obj_inst->shard_manager()->seal_shard(1).get();
+    ASSERT_TRUE(std::holds_alternative< ShardError >(v));
+    EXPECT_EQ(std::get< ShardError >(v), ShardError::UNKNOWN_SHARD);
 }
 
 TEST_F(HomeObjectFixture, PutBlobMissingShard) {
-    _obj_inst->blob_manager()->put(1,
-                                   homeobject::Blob{std::make_unique< sisl::byte_array_impl >(4096), "user_key", 0ul},
-                                   [this](auto const& v, auto opt) {
-                                       ASSERT_TRUE(std::holds_alternative< BlobError >(v));
-                                       EXPECT_EQ(std::get< BlobError >(v), BlobError::UNKNOWN_SHARD);
-                                       _t.signal();
-                                   });
+    auto v = _obj_inst->blob_manager()
+                 ->put(1, homeobject::Blob{std::make_unique< sisl::byte_array_impl >(4096), "user_key", 0ul})
+                 .get();
+    ASSERT_TRUE(std::holds_alternative< BlobError >(v));
+    EXPECT_EQ(std::get< BlobError >(v), BlobError::UNKNOWN_SHARD);
 }
 
 TEST_F(HomeObjectFixture, GetBlobMissingShard) {
-    _obj_inst->blob_manager()->get(1, 0u, 0ul, UINT64_MAX, [this](auto const& v, auto opt) {
-        ASSERT_TRUE(std::holds_alternative< BlobError >(v));
-        EXPECT_EQ(std::get< BlobError >(v), BlobError::UNKNOWN_SHARD);
-        _t.signal();
-    });
+    auto v = _obj_inst->blob_manager()->get(1, 0u, 0ul, UINT64_MAX).get();
+    ASSERT_TRUE(std::holds_alternative< BlobError >(v));
+    EXPECT_EQ(std::get< BlobError >(v), BlobError::UNKNOWN_SHARD);
 }
 
 TEST_F(HomeObjectFixture, DeleteBlobMissingShard) {
-    _obj_inst->blob_manager()->del(1, 0u, [this](auto const& e, auto opt) {
-        EXPECT_EQ(e, BlobError::UNKNOWN_SHARD);
-        _t.signal();
-    });
+    EXPECT_EQ(_obj_inst->blob_manager()->del(1, 0u).get(), BlobError::UNKNOWN_SHARD);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
SemiFutures have "context erasure" for any continuations HomeObject
attches itself to the generated promise.