### PR TITLE
No need for a lock around the ShardIndex.

### DIFF
--- a/src/lib/memory/blob_manager.cpp
+++ b/src/lib/memory/blob_manager.cpp
@@ -3,10 +3,9 @@
 namespace homeobject {
 
 Shard& MemoryHomeObject::_find_index(shard_id shard) {
-    auto lg = std::shared_lock(_index_lock);
     auto index_it = _in_memory_index.find(shard);
     RELEASE_ASSERT(_in_memory_index.end() != index_it, "Missing BTree!!");
-    return index_it->second;
+    return *index_it->second;
 }
 
 BlobManager::Result< blob_id > MemoryHomeObject::_put_blob(ShardInfo const& shard, Blob&& blob) {
@@ -30,11 +29,10 @@ BlobManager::Result< Blob > MemoryHomeObject::_get_blob(ShardInfo const& shard, 
     // Lookup Shard Index (BTree and SSN)
     auto index_it = _in_memory_index.cend();
     {
-        auto lg = std::shared_lock(_index_lock);
         if (index_it = _in_memory_index.find(shard.id); _in_memory_index.cend() == index_it)
             return folly::makeUnexpected(BlobError::UNKNOWN_SHARD);
     }
-    auto& our_shard = index_it->second;
+    auto& our_shard = *index_it->second;
 
     // Calculate BlobRoute from ShardInfo (use ordinal?)
     auto route = BlobRoute(shard.id, blob);

--- a/src/lib/memory/homeobject.hpp
+++ b/src/lib/memory/homeobject.hpp
@@ -52,7 +52,7 @@ struct Shard {
 
 class MemoryHomeObject : public HomeObjectImpl {
     /// Simulates the Shard=>Chunk mapping in IndexSvc
-    using index_svc = folly::ConcurrentHashMap< shard_id, std::shared_ptr< Shard > >;
+    using index_svc = folly::ConcurrentHashMap< shard_id, std::unique_ptr< Shard > >;
     index_svc _in_memory_index;
     ///
 

--- a/src/lib/memory/homeobject.hpp
+++ b/src/lib/memory/homeobject.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <shared_mutex>
 #include <utility>
 
 #include <folly/concurrency/ConcurrentHashMap.h>
@@ -53,8 +52,7 @@ struct Shard {
 
 class MemoryHomeObject : public HomeObjectImpl {
     /// Simulates the Shard=>Chunk mapping in IndexSvc
-    mutable std::shared_mutex _index_lock;
-    using index_svc = std::unordered_map< shard_id, Shard >;
+    using index_svc = folly::ConcurrentHashMap< shard_id, std::shared_ptr< Shard > >;
     index_svc _in_memory_index;
     ///
 

--- a/src/lib/memory/shard_manager.cpp
+++ b/src/lib/memory/shard_manager.cpp
@@ -30,7 +30,7 @@ ShardManager::Result< ShardInfo > MemoryHomeObject::_create_shard(pg_id pg_owner
         auto [_, s_happened] = _shard_map.emplace(info.id, s_it);
         RELEASE_ASSERT(s_happened, "Duplicate Shard insertion!");
     }
-    auto [it, happened] = _in_memory_index.try_emplace(info.id, std::make_shared< Shard >());
+    auto [it, happened] = _in_memory_index.try_emplace(info.id, std::make_unique< Shard >());
     RELEASE_ASSERT(happened, "Could not create BTree!");
     return info;
 }

--- a/src/lib/memory/shard_manager.cpp
+++ b/src/lib/memory/shard_manager.cpp
@@ -30,8 +30,7 @@ ShardManager::Result< ShardInfo > MemoryHomeObject::_create_shard(pg_id pg_owner
         auto [_, s_happened] = _shard_map.emplace(info.id, s_it);
         RELEASE_ASSERT(s_happened, "Duplicate Shard insertion!");
     }
-    auto lg = std::scoped_lock(_index_lock);
-    auto [_, happened] = _in_memory_index.try_emplace(info.id);
+    auto [it, happened] = _in_memory_index.try_emplace(info.id, std::make_shared< Shard >());
     RELEASE_ASSERT(happened, "Could not create BTree!");
     return info;
 }


### PR DESCRIPTION
This is the last lock left in the MemoryHomeObject implementation. The rest are in HomeObectImpl currently.