### PR TITLE
add interface to get blk alloc hints for chunks on same pg

### DIFF
--- a/src/lib/homestore/heap_chunk_selector.cpp
+++ b/src/lib/homestore/heap_chunk_selector.cpp
@@ -118,10 +118,10 @@ void HeapChunkSelector::build_per_dev_chunk_heap(const std::unordered_set< chunk
     };
 }
 
-homestore::blk_alloc_hints HeapChunkSelector::get_blk_alloc_hints_on_same_pdev(chunk_num_t chunk_id) const {
+homestore::blk_alloc_hints HeapChunkSelector::chunk_to_hints(chunk_num_t chunk_id) const {
     auto iter = m_chunks.find(chunk_id);
     if (iter == m_chunks.end()) {
-        LOGWARN("No chunk found for ChunkID {}, will return default blk alloc hints", chunk_id);
+        LOGWARNMOD(homeobject, "No chunk found for chunk_id {}, will return default blk alloc hints", chunk_id);
         return homestore::blk_alloc_hints();
     }
     homestore::blk_alloc_hints hints;

--- a/src/lib/homestore/heap_chunk_selector.cpp
+++ b/src/lib/homestore/heap_chunk_selector.cpp
@@ -117,4 +117,16 @@ void HeapChunkSelector::build_per_dev_chunk_heap(const std::unordered_set< chunk
         if (excludingChunks.find(p.first) == excludingChunks.end()) { add_chunk_internal(p.first); }
     };
 }
+
+homestore::blk_alloc_hints HeapChunkSelector::get_blk_alloc_hints_on_same_pdev(chunk_num_t chunk_id) const {
+    auto iter = m_chunks.find(chunk_id);
+    if (iter == m_chunks.end()) {
+        LOGWARN("No chunk found for ChunkID {}, will return default blk alloc hints", chunk_id);
+        return homestore::blk_alloc_hints();
+    }
+    homestore::blk_alloc_hints hints;
+    hints.pdev_id_hint = VChunk(iter->second).get_pdev_id();
+    return hints;
+}
+
 } // namespace homeobject

--- a/src/lib/homestore/heap_chunk_selector.h
+++ b/src/lib/homestore/heap_chunk_selector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "homeobject/common.hpp"
+
 #include <homestore/chunk_selector.h>
 #include <homestore/vchunk.h>
 #include <homestore/homestore_decl.hpp>
@@ -46,7 +48,7 @@ public:
     // this should be called after ShardManager is initialized and get all the open shards
     void build_per_dev_chunk_heap(const std::unordered_set< chunk_num_t >& excludingChunks);
 
-    homestore::blk_alloc_hints get_blk_alloc_hints_on_same_pdev(chunk_num_t chunk_id) const;
+    homestore::blk_alloc_hints chunk_to_hints(chunk_num_t chunk_id) const;
 
 private:
     std::unordered_map< uint32_t, std::shared_ptr< PerDevHeap > > m_per_dev_heap;

--- a/src/lib/homestore/heap_chunk_selector.h
+++ b/src/lib/homestore/heap_chunk_selector.h
@@ -46,6 +46,8 @@ public:
     // this should be called after ShardManager is initialized and get all the open shards
     void build_per_dev_chunk_heap(const std::unordered_set< chunk_num_t >& excludingChunks);
 
+    homestore::blk_alloc_hints get_blk_alloc_hints_on_same_pdev(chunk_num_t chunk_id) const;
+
 private:
     std::unordered_map< uint32_t, std::shared_ptr< PerDevHeap > > m_per_dev_heap;
 


### PR DESCRIPTION
HO will try to make all shards on same PG to be located in same HS pdev, but current HO does not know pdev id at all because pdev is managed by HS. In order to do that, we can reuse the HeapChunkSelector logic and its inner data members and add an interface which will return blk_alloc_hints for different shards on same PG.