### PR TITLE
Support different Executors.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "0.12.1"
+    version = "0.13.1"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -4,6 +4,7 @@ add_flags("-Wno-unused-parameter")
 
 add_library(${PROJECT_NAME}_core OBJECT)
 target_sources(${PROJECT_NAME}_core PRIVATE
+            homeobject_impl.cpp
             blob_manager.cpp
             shard_manager.cpp
             pg_manager.cpp

--- a/src/lib/homeobject_impl.cpp
+++ b/src/lib/homeobject_impl.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-SISL_OPTION_GROUP(homeobject_options,
+SISL_OPTION_GROUP(homeobject,
                   (executor_type, "", "executor", "Executor to use for Future deferal",
                    ::cxxopts::value< std::string >()->default_value("immediate"), "immediate|cpu|io"));
 

--- a/src/lib/homeobject_impl.cpp
+++ b/src/lib/homeobject_impl.cpp
@@ -1,0 +1,27 @@
+#include "homeobject_impl.hpp"
+
+#include <algorithm>
+
+SISL_OPTION_GROUP(homeobject_options,
+                  (executor_type, "", "executor", "Executor to use for Future deferal",
+                   ::cxxopts::value< std::string >()->default_value("immediate"), "immediate|cpu|io"));
+
+namespace homeobject {
+
+HomeObjectImpl::HomeObjectImpl(std::weak_ptr< HomeObjectApplication >&& application) :
+        _application(std::move(application)) {
+    auto exe_type = SISL_OPTIONS["executor"].as< std::string >();
+    std::transform(exe_type.begin(), exe_type.end(), exe_type.begin(), ::tolower);
+
+    if ("immediate" == exe_type) [[likely]]
+        executor_ = &folly::QueuedImmediateExecutor::instance();
+    else if ("io" == exe_type)
+        executor_ = folly::getGlobalIOExecutor();
+    else if ("cpu" == exe_type)
+        executor_ = folly::getGlobalCPUExecutor();
+    else
+        RELEASE_ASSERT(false, "Unknown Folly Executor type: [{}]", exe_type);
+    LOGI("initialized with [executor={}]", exe_type);
+}
+
+} // namespace homeobject

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -42,6 +42,6 @@ target_link_libraries(blob_homestore_test
     homeobject_homestore
     ${COMMON_TEST_DEPS}
   )
-add_test(NAME BlobHomestoreTest COMMAND blob_homestore_test -csv error --num_iters 1000)
+add_test(NAME BlobHomestoreTest COMMAND blob_homestore_test -csv error --executor immediate)
 set_property(TEST BlobHomestoreTest PROPERTY RUN_SERIAL 1)
 endif()

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -18,30 +18,15 @@ target_link_libraries("${PROJECT_NAME}_homestore"
 if(BUILD_TESTING)
     add_subdirectory(tests)
 
-add_executable (pg_homestore_test)
-target_sources(pg_homestore_test PRIVATE $<TARGET_OBJECTS:pg_test>)
-target_link_libraries(pg_homestore_test
-    homeobject_homestore
-    ${COMMON_TEST_DEPS}
-  )
-add_test(NAME PGHomestoreTest COMMAND pg_homestore_test -csv error)
-set_property(TEST PGHomestoreTest PROPERTY RUN_SERIAL 1)
-
-add_executable (shard_homestore_test)
-target_sources(shard_homestore_test PRIVATE $<TARGET_OBJECTS:shard_test>)
-target_link_libraries(shard_homestore_test
-    homeobject_homestore
-    ${COMMON_TEST_DEPS}
-  )
-add_test(NAME ShardHomestoreTest COMMAND shard_homestore_test -csv error)
-set_property(TEST ShardHomestoreTest PROPERTY RUN_SERIAL 1)
-
-add_executable (blob_homestore_test)
-target_sources(blob_homestore_test PRIVATE $<TARGET_OBJECTS:blob_test>)
-target_link_libraries(blob_homestore_test
-    homeobject_homestore
-    ${COMMON_TEST_DEPS}
-  )
-add_test(NAME BlobHomestoreTest COMMAND blob_homestore_test -csv error --executor immediate)
-set_property(TEST BlobHomestoreTest PROPERTY RUN_SERIAL 1)
+    add_executable (homestore_test)
+    target_sources(homestore_test PRIVATE
+        $<TARGET_OBJECTS:homestore_tests>
+        $<TARGET_OBJECTS:test_fixture>
+        )
+    target_link_libraries(homestore_test
+        homeobject_homestore
+        ${COMMON_TEST_DEPS}
+      )
+    add_test(NAME HomestoreTest COMMAND homestore_test -csv error --executor immediate)
+    set_property(TEST HomestoreTest PROPERTY RUN_SERIAL 1)
 endif()

--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -179,7 +179,7 @@ BlobManager::AsyncResult< Blob > HSHomeObject::_get_blob(ShardInfo const& shard,
 
     auto r = get_from_index_table(index_table, shard.id, blob_id);
     if (!r) {
-        LOGW("Blob not found in index id {} shard {}", blob_id, shard.id);
+        LOGW("Blob not found in index [route={}]", BlobRoute{blob_id, shard.id});
         return folly::makeUnexpected(r.error());
     }
 

--- a/src/lib/homestore_backend/index_kv.cpp
+++ b/src/lib/homestore_backend/index_kv.cpp
@@ -66,7 +66,7 @@ HSHomeObject::get_from_index_table(shared< BlobIndexTable > index_table, shard_i
     homestore::BtreeSingleGetRequest get_req{&index_key, &index_value};
     auto status = index_table->get(get_req);
     if (status != homestore::btree_status_t::success) {
-        LOGERROR("Failed to get from index table [route={}]", index_key);
+        LOGDEBUG("Failed to get from index table [route={}]", index_key);
         return folly::makeUnexpected(BlobError::UNKNOWN_BLOB);
     }
 

--- a/src/lib/homestore_backend/tests/CMakeLists.txt
+++ b/src/lib/homestore_backend/tests/CMakeLists.txt
@@ -2,26 +2,19 @@ cmake_minimum_required(VERSION 3.13)
 
 include_directories (BEFORE .)
 
-add_executable(hs_blob_tests)
-target_sources(hs_blob_tests PRIVATE hs_blob_tests.cpp)
-target_link_libraries(hs_blob_tests
+list(APPEND TEST_SOURCES
+    test_heap_chunk_selector.cpp
+    hs_shard_tests.cpp
+    )
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+list(APPEND TEST_SOURCES
+    hs_blob_tests.cpp
+    )
+endif()
+
+add_library(homestore_tests OBJECT)
+target_sources(homestore_tests PRIVATE ${TEST_SOURCES})
+target_link_libraries(homestore_tests
             homeobject_homestore
             ${COMMON_TEST_DEPS}
         )
-add_test(NAME HSBlobTests COMMAND ${CMAKE_BINARY_DIR}/bin/hs_blob_tests)
-set_property(TEST HSBlobTests PROPERTY RUN_SERIAL 1)
-
-add_executable (hs_shard_tests)
-target_sources(hs_shard_tests PRIVATE hs_shard_tests.cpp)
-target_link_libraries(hs_shard_tests
-            homeobject_homestore
-            ${COMMON_TEST_DEPS}
-)
-add_test(NAME HSShardTests COMMAND ${CMAKE_BINARY_DIR}/bin/hs_shard_tests)
-set_property(TEST HSShardTests PROPERTY RUN_SERIAL 1)
-
-add_executable (test_heap_chunk_selector)
-target_sources(test_heap_chunk_selector PRIVATE test_heap_chunk_selector.cpp ../heap_chunk_selector.cpp)
-target_link_libraries(test_heap_chunk_selector homeobject_homestore ${COMMON_TEST_DEPS})
-add_test(NAME HeapChunkSelectorTest COMMAND ${CMAKE_BINARY_DIR}/bin/test_heap_chunk_selector)
-

--- a/src/lib/homestore_backend/tests/CMakeLists.txt
+++ b/src/lib/homestore_backend/tests/CMakeLists.txt
@@ -3,14 +3,9 @@ cmake_minimum_required(VERSION 3.13)
 include_directories (BEFORE .)
 
 list(APPEND TEST_SOURCES
-    test_heap_chunk_selector.cpp
     hs_shard_tests.cpp
-    )
-if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-list(APPEND TEST_SOURCES
     hs_blob_tests.cpp
     )
-endif()
 
 add_library(homestore_tests OBJECT)
 target_sources(homestore_tests PRIVATE ${TEST_SOURCES})
@@ -18,3 +13,8 @@ target_link_libraries(homestore_tests
             homeobject_homestore
             ${COMMON_TEST_DEPS}
         )
+
+add_executable (test_heap_chunk_selector)
+target_sources(test_heap_chunk_selector PRIVATE test_heap_chunk_selector.cpp ../heap_chunk_selector.cpp)
+target_link_libraries(test_heap_chunk_selector homeobject_homestore ${COMMON_TEST_DEPS})
+add_test(NAME HeapChunkSelectorTest COMMAND ${CMAKE_BINARY_DIR}/bin/test_heap_chunk_selector)

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -1,19 +1,13 @@
 #include <chrono>
 #include <cmath>
-#include <condition_variable>
 #include <mutex>
 
-#include <folly/init/Init.h>
-#include <gtest/gtest.h>
-#include <sisl/logging/logging.h>
-#include <sisl/options/options.h>
-
 #include <boost/uuid/random_generator.hpp>
+#include <gtest/gtest.h>
 
 #include "lib/homestore_backend/hs_homeobject.hpp"
-#include "bits_generator.hpp"
-
 #include "lib/tests/fixture_app.hpp"
+#include "bits_generator.hpp"
 
 using namespace std::chrono_literals;
 
@@ -246,15 +240,4 @@ TEST_F(HomeObjectFixture, SealShardWithRestart) {
     ASSERT_TRUE(!b);
     ASSERT_EQ(b.error(), BlobError::SEALED_SHARD);
     LOGINFO("Put blob {}", b.error());
-}
-
-int main(int argc, char* argv[]) {
-    int parsed_argc = argc;
-    ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
-    sisl::logging::SetLogger(std::string(argv[0]));
-    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
-    parsed_argc = 1;
-    auto f = ::folly::Init(&parsed_argc, &argv, true);
-    return RUN_ALL_TESTS();
 }

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -251,7 +251,7 @@ TEST_F(HomeObjectFixture, SealShardWithRestart) {
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_home_object);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
     parsed_argc = 1;

--- a/src/lib/homestore_backend/tests/hs_shard_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_shard_tests.cpp
@@ -1,16 +1,11 @@
 #include <string>
 
 #include <boost/uuid/random_generator.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <folly/init/Init.h>
 
 #include <homestore/blkdata_service.hpp>
 #include <homestore/logstore_service.hpp>
 
 #include <gtest/gtest.h>
-
-#include <sisl/logging/logging.h>
-#include <sisl/options/options.h>
 
 // will allow unit tests to access object private/protected for validation;
 #define protected public
@@ -212,15 +207,4 @@ TEST_F(ShardManagerTestingRecovery, ShardManagerRecovery) {
     EXPECT_TRUE(hs_shard->sb_->available_capacity_bytes == shard_info.available_capacity_bytes);
     EXPECT_TRUE(hs_shard->sb_->total_capacity_bytes == shard_info.total_capacity_bytes);
     EXPECT_TRUE(hs_shard->sb_->deleted_capacity_bytes == shard_info.deleted_capacity_bytes);
-}
-
-int main(int argc, char* argv[]) {
-    int parsed_argc = argc;
-    ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
-    sisl::logging::SetLogger(std::string(argv[0]));
-    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
-    parsed_argc = 1;
-    auto f = ::folly::Init(&parsed_argc, &argv, true);
-    return RUN_ALL_TESTS();
 }

--- a/src/lib/homestore_backend/tests/hs_shard_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_shard_tests.cpp
@@ -217,7 +217,7 @@ TEST_F(ShardManagerTestingRecovery, ShardManagerRecovery) {
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
     parsed_argc = 1;

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -2,7 +2,14 @@
 
 #include <gtest/gtest.h>
 
+#include <sisl/options/options.h>
+#include <sisl/logging/logging.h>
+#include <folly/init/Init.h>
+
 #include <memory>
+
+SISL_LOGGING_INIT(logging, HOMEOBJECT_LOG_MODS)
+SISL_OPTIONS_ENABLE(logging)
 
 namespace homestore {
 
@@ -115,4 +122,15 @@ TEST_F(HeapChunkSelectorTest, test_release_chunk) {
     chunk2 = HCS.select_chunk(count, hints);
     ASSERT_EQ(chunk2->get_pdev_id(), 1);
     ASSERT_EQ(chunk2->available_blks(), 2);
+}
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    parsed_argc = 1;
+    auto f = ::folly::Init(&parsed_argc, &argv, true);
+    return RUN_ALL_TESTS();
 }

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -2,14 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include <sisl/options/options.h>
-#include <sisl/logging/logging.h>
-#include <folly/init/Init.h>
-
 #include <memory>
-
-SISL_LOGGING_INIT(logging, HOMEOBJECT_LOG_MODS)
-SISL_OPTIONS_ENABLE(logging)
 
 namespace homestore {
 
@@ -122,15 +115,4 @@ TEST_F(HeapChunkSelectorTest, test_release_chunk) {
     chunk2 = HCS.select_chunk(count, hints);
     ASSERT_EQ(chunk2->get_pdev_id(), 1);
     ASSERT_EQ(chunk2->available_blks(), 2);
-}
-
-int main(int argc, char* argv[]) {
-    int parsed_argc = argc;
-    ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
-    sisl::logging::SetLogger(std::string(argv[0]));
-    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
-    parsed_argc = 1;
-    auto f = ::folly::Init(&parsed_argc, &argv, true);
-    return RUN_ALL_TESTS();
 }

--- a/src/lib/memory_backend/CMakeLists.txt
+++ b/src/lib/memory_backend/CMakeLists.txt
@@ -13,28 +13,12 @@ target_link_libraries("${PROJECT_NAME}_memory"
 )
 
 if(BUILD_TESTING)
-add_executable (pg_memory_test)
-target_sources(pg_memory_test PRIVATE $<TARGET_OBJECTS:pg_test>)
-target_link_libraries(pg_memory_test
+add_executable (memory_test)
+target_sources(memory_test PRIVATE $<TARGET_OBJECTS:test_fixture>)
+target_link_libraries(memory_test
     homeobject_memory
     ${COMMON_TEST_DEPS}
   )
-add_test(NAME PGMemoryTest COMMAND pg_memory_test -csv error)
-
-add_executable (shard_memory_test)
-target_sources(shard_memory_test PRIVATE $<TARGET_OBJECTS:shard_test>)
-target_link_libraries(shard_memory_test
-    homeobject_memory
-    ${COMMON_TEST_DEPS}
-  )
-add_test(NAME ShardMemoryTest COMMAND shard_memory_test -csv error)
-
-add_executable (blob_memory_test)
-target_sources(blob_memory_test PRIVATE $<TARGET_OBJECTS:blob_test>)
-target_link_libraries(blob_memory_test
-    homeobject_memory
-    ${COMMON_TEST_DEPS}
-  )
-add_test(NAME BlobMemoryTestCPU COMMAND blob_memory_test -csv error --num_iters 20000 --executor cpu)
-add_test(NAME BlobMemoryTestImmediate COMMAND blob_memory_test -csv error --executor io)
+add_test(NAME MemoryTestCPU COMMAND memory_test -csv error --executor cpu --num_iters 20000)
+add_test(NAME MemoryTestIO COMMAND memory_test -csv error --executor io --num_iters 20000)
 endif()

--- a/src/lib/memory_backend/CMakeLists.txt
+++ b/src/lib/memory_backend/CMakeLists.txt
@@ -35,5 +35,6 @@ target_link_libraries(blob_memory_test
     homeobject_memory
     ${COMMON_TEST_DEPS}
   )
-add_test(NAME BlobMemoryTest COMMAND blob_memory_test -csv error)
+add_test(NAME BlobMemoryTestCPU COMMAND blob_memory_test -csv error --num_iters 20000 --executor cpu)
+add_test(NAME BlobMemoryTestImmediate COMMAND blob_memory_test -csv error --executor io)
 endif()

--- a/src/lib/tests/BlobManagerTest.cpp
+++ b/src/lib/tests/BlobManagerTest.cpp
@@ -70,7 +70,7 @@ TEST_F(TestFixture, BasicTests) {
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_home_object);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
     parsed_argc = 1;

--- a/src/lib/tests/BlobManagerTest.cpp
+++ b/src/lib/tests/BlobManagerTest.cpp
@@ -1,12 +1,13 @@
 #include <mutex>
-
-#include <folly/init/Init.h>
 #include <folly/executors/GlobalExecutor.h>
 
 #include <homeobject/blob_manager.hpp>
 #include "lib/tests/fixture_app.hpp"
 
-TEST_F(TestFixture, BasicTests) {
+using homeobject::Blob;
+using homeobject::BlobError;
+
+TEST_F(TestFixture, BasicBlobTests) {
     auto const batch_sz = 4;
     std::mutex call_lock;
     auto calls = std::list< folly::SemiFuture< folly::Unit > >();
@@ -65,15 +66,4 @@ TEST_F(TestFixture, BasicTests) {
     homeobj_->blob_manager()->del(_shard_1.id, _blob_id).get();
     homeobj_->blob_manager()->get(_shard_1.id, _blob_id).get();
     homeobj_->blob_manager()->del(_shard_1.id, _blob_id).get();
-}
-
-int main(int argc, char* argv[]) {
-    int parsed_argc = argc;
-    ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
-    sisl::logging::SetLogger(std::string(argv[0]));
-    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
-    parsed_argc = 1;
-    auto f = ::folly::Init(&parsed_argc, &argv, true);
-    return RUN_ALL_TESTS();
 }

--- a/src/lib/tests/CMakeLists.txt
+++ b/src/lib/tests/CMakeLists.txt
@@ -1,19 +1,12 @@
 cmake_minimum_required (VERSION 3.11)
 
-add_library (pg_test OBJECT)
-target_sources(pg_test PRIVATE PGManagerTest.cpp)
-target_link_libraries(pg_test
-    ${COMMON_TEST_DEPS}
-  )
-
-add_library (shard_test OBJECT)
-target_sources(shard_test PRIVATE ShardManagerTest.cpp)
-target_link_libraries(shard_test
-    ${COMMON_TEST_DEPS}
-  )
-
-add_library (blob_test OBJECT)
-target_sources(blob_test PRIVATE BlobManagerTest.cpp)
-target_link_libraries(blob_test
+add_library (test_fixture OBJECT)
+target_sources(test_fixture PRIVATE
+    BlobManagerTest.cpp
+    ShardManagerTest.cpp
+    PGManagerTest.cpp
+    fixture_app.cpp
+    )
+target_link_libraries(test_fixture
     ${COMMON_TEST_DEPS}
   )

--- a/src/lib/tests/PGManagerTest.cpp
+++ b/src/lib/tests/PGManagerTest.cpp
@@ -62,7 +62,7 @@ TEST_F(TestFixture, Migrate) {
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
     parsed_argc = 1;

--- a/src/lib/tests/PGManagerTest.cpp
+++ b/src/lib/tests/PGManagerTest.cpp
@@ -1,7 +1,4 @@
 #include <boost/uuid/random_generator.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <folly/init/Init.h>
-#include <folly/executors/GlobalExecutor.h>
 
 #include <homeobject/pg_manager.hpp>
 #include "lib/tests/fixture_app.hpp"
@@ -57,15 +54,4 @@ TEST_F(TestFixture, Migrate) {
               PGError::INVALID_ARG);
     EXPECT_FALSE(
         homeobj_->pg_manager()->replace_member(_pg_id, _peer2, PGMember{boost::uuids::random_generator()()}).get());
-}
-
-int main(int argc, char* argv[]) {
-    int parsed_argc = argc;
-    ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
-    sisl::logging::SetLogger(std::string(argv[0]));
-    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
-    parsed_argc = 1;
-    auto f = ::folly::Init(&parsed_argc, &argv, true);
-    return RUN_ALL_TESTS();
 }

--- a/src/lib/tests/ShardManagerTest.cpp
+++ b/src/lib/tests/ShardManagerTest.cpp
@@ -70,7 +70,7 @@ TEST_F(TestFixture, SealShard) {
 int main(int argc, char* argv[]) {
     int parsed_argc = argc;
     ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
     parsed_argc = 1;

--- a/src/lib/tests/ShardManagerTest.cpp
+++ b/src/lib/tests/ShardManagerTest.cpp
@@ -1,6 +1,3 @@
-#include <folly/init/Init.h>
-#include <folly/executors/GlobalExecutor.h>
-
 #include <homeobject/shard_manager.hpp>
 #include "lib/tests/fixture_app.hpp"
 
@@ -65,15 +62,4 @@ TEST_F(TestFixture, SealShard) {
             EXPECT_EQ(info.state, ShardInfo::State::SEALED);
         });
     }
-}
-
-int main(int argc, char* argv[]) {
-    int parsed_argc = argc;
-    ::testing::InitGoogleTest(&parsed_argc, argv);
-    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, homeobject_options, test_home_object);
-    sisl::logging::SetLogger(std::string(argv[0]));
-    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
-    parsed_argc = 1;
-    auto f = ::folly::Init(&parsed_argc, &argv, true);
-    return RUN_ALL_TESTS();
 }

--- a/src/lib/tests/fixture_app.cpp
+++ b/src/lib/tests/fixture_app.cpp
@@ -1,0 +1,77 @@
+#include <boost/uuid/random_generator.hpp>
+#include <folly/init/Init.h>
+#include <ostream>
+
+#include "fixture_app.hpp"
+
+SISL_OPTION_GROUP(
+    test_home_object,
+    (num_iters, "", "num_iters", "number of iterations per loop", ::cxxopts::value< uint64_t >()->default_value("1000"),
+     "number"),
+    (num_pgs, "", "num_pgs", "number of pgs", ::cxxopts::value< uint64_t >()->default_value("10"), "number"),
+    (num_shards, "", "num_shards", "number of shards", ::cxxopts::value< uint64_t >()->default_value("20"), "number"),
+    (num_blobs, "", "num_blobs", "number of blobs", ::cxxopts::value< uint64_t >()->default_value("50"), "number"));
+
+SISL_LOGGING_INIT(logging, HOMEOBJECT_LOG_MODS)
+
+SISL_OPTIONS_ENABLE(logging, iomgr, homeobject, test_home_object)
+
+FixtureApp::FixtureApp() {
+    clean();
+    LOGINFO("creating device {} file with size {} ", path_, homestore::in_bytes(2 * Gi));
+    std::ofstream ofs{path_, std::ios::binary | std::ios::out | std::ios::trunc};
+    std::filesystem::resize_file(path_, 2 * Gi);
+}
+
+void TestFixture::SetUp() {
+    app = std::make_shared< FixtureApp >();
+    homeobj_ = homeobject::init_homeobject(std::weak_ptr< homeobject::HomeObjectApplication >(app));
+    _peer1 = homeobj_->our_uuid();
+    _peer2 = boost::uuids::random_generator()();
+
+    auto info = homeobject::PGInfo(_pg_id);
+    info.members.insert(homeobject::PGMember{_peer1, "peer1", 1});
+    info.members.insert(homeobject::PGMember{_peer2, "peer2", 0});
+
+    LOGDEBUG("Setup Pg");
+    EXPECT_TRUE(homeobj_->pg_manager()->create_pg(std::move(info)).get());
+
+    LOGDEBUG("Setup Shards");
+    auto s_e = homeobj_->shard_manager()->create_shard(_pg_id, Mi).get();
+    ASSERT_TRUE(!!s_e);
+    s_e.then([this](auto&& i) { _shard_1 = std::move(i); });
+
+    s_e = homeobj_->shard_manager()->create_shard(_pg_id, Mi).get();
+    ASSERT_TRUE(!!s_e);
+    s_e.then([this](auto&& i) { _shard_2 = std::move(i); });
+
+    LOGDEBUG("Get on empty Shard: {}", _shard_1.id);
+    auto g_e = homeobj_->blob_manager()->get(_shard_1.id, 0).get();
+    ASSERT_FALSE(g_e);
+    EXPECT_EQ(homeobject::BlobError::UNKNOWN_BLOB, g_e.error());
+
+    LOGDEBUG("Insert Blob to: {}", _shard_1.id);
+    auto o_e = homeobj_->blob_manager()
+                   ->put(_shard_1.id, homeobject::Blob{sisl::io_blob_safe(4 * Ki, 512u), "test_blob", 4 * Mi})
+                   .get();
+    EXPECT_TRUE(!!o_e);
+    o_e.then([this](auto&& b) mutable { _blob_id = std::move(b); });
+
+    g_e = homeobj_->blob_manager()->get(_shard_1.id, _blob_id).get();
+    EXPECT_TRUE(!!g_e);
+    g_e.then([](auto&& blob) {
+        EXPECT_STREQ(blob.user_key.c_str(), "test_blob");
+        EXPECT_EQ(blob.object_off, 4 * Mi);
+    });
+}
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, iomgr, homeobject, test_home_object);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    parsed_argc = 1;
+    auto f = ::folly::Init(&parsed_argc, &argv, true);
+    return RUN_ALL_TESTS();
+}

--- a/src/lib/tests/fixture_app.hpp
+++ b/src/lib/tests/fixture_app.hpp
@@ -19,7 +19,7 @@ using homeobject::blob_id_t;
 using homeobject::peer_id_t;
 
 class FixtureApp : public homeobject::HomeObjectApplication {
-    std::string path_{"/tmp/homobject_test.data"};
+    std::string path_{"/tmp/homeobject_test.data"};
 
 public:
     FixtureApp();

--- a/src/lib/tests/fixture_app.hpp
+++ b/src/lib/tests/fixture_app.hpp
@@ -19,13 +19,13 @@ SISL_LOGGING_INIT(logging, HOMEOBJECT_LOG_MODS)
 
 SISL_OPTION_GROUP(
     test_home_object,
-    (num_iters, "", "num_iters", "number of iterations per loop",
-     ::cxxopts::value< uint64_t >()->default_value("100000"), "number"),
+    (num_iters, "", "num_iters", "number of iterations per loop", ::cxxopts::value< uint64_t >()->default_value("1000"),
+     "number"),
     (num_pgs, "", "num_pgs", "number of pgs", ::cxxopts::value< uint64_t >()->default_value("10"), "number"),
     (num_shards, "", "num_shards", "number of shards", ::cxxopts::value< uint64_t >()->default_value("20"), "number"),
     (num_blobs, "", "num_blobs", "number of blobs", ::cxxopts::value< uint64_t >()->default_value("50"), "number"));
 
-SISL_OPTIONS_ENABLE(logging, test_home_object)
+SISL_OPTIONS_ENABLE(logging, homeobject_options, test_home_object)
 
 using homeobject::Blob;
 using homeobject::blob_id_t;

--- a/src/lib/tests/fixture_app.hpp
+++ b/src/lib/tests/fixture_app.hpp
@@ -1,12 +1,12 @@
+#pragma once
+
 #include <filesystem>
 #include <list>
 #include <memory>
 #include <string>
 #include <optional>
-#include <ostream>
 
 #include <gtest/gtest.h>
-#include <boost/uuid/random_generator.hpp>
 #include <sisl/logging/logging.h>
 #include <sisl/options/options.h>
 
@@ -15,34 +15,14 @@
 #include <homeobject/shard_manager.hpp>
 #include <homeobject/blob_manager.hpp>
 
-SISL_LOGGING_INIT(logging, HOMEOBJECT_LOG_MODS)
-
-SISL_OPTION_GROUP(
-    test_home_object,
-    (num_iters, "", "num_iters", "number of iterations per loop", ::cxxopts::value< uint64_t >()->default_value("1000"),
-     "number"),
-    (num_pgs, "", "num_pgs", "number of pgs", ::cxxopts::value< uint64_t >()->default_value("10"), "number"),
-    (num_shards, "", "num_shards", "number of shards", ::cxxopts::value< uint64_t >()->default_value("20"), "number"),
-    (num_blobs, "", "num_blobs", "number of blobs", ::cxxopts::value< uint64_t >()->default_value("50"), "number"));
-
-SISL_OPTIONS_ENABLE(logging, homeobject_options, test_home_object)
-
-using homeobject::Blob;
 using homeobject::blob_id_t;
-using homeobject::BlobError;
 using homeobject::peer_id_t;
 
 class FixtureApp : public homeobject::HomeObjectApplication {
-    std::string path_{"/tmp/homobject_test.data." + std::to_string(rand())};
+    std::string path_{"/tmp/homobject_test.data"};
 
 public:
-    FixtureApp() {
-        clean();
-        LOGINFO("creating device {} file with size {} ", path_, homestore::in_bytes(2 * Gi));
-        std::ofstream ofs{path_, std::ios::binary | std::ios::out | std::ios::trunc};
-        std::filesystem::resize_file(path_, 2 * Gi);
-    }
-
+    FixtureApp();
     ~FixtureApp() override { clean(); }
 
     bool spdk_mode() const override { return false; }
@@ -65,7 +45,7 @@ public:
 };
 
 class TestFixture : public ::testing::Test {
-    std::shared_ptr< FixtureApp > app;
+    std::shared_ptr< homeobject::HomeObjectApplication > app;
 
 public:
     homeobject::ShardInfo _shard_1;
@@ -75,47 +55,7 @@ public:
     peer_id_t _peer2;
     blob_id_t _blob_id;
 
-    void SetUp() override {
-        app = std::make_shared< FixtureApp >();
-        homeobj_ = homeobject::init_homeobject(std::weak_ptr< homeobject::HomeObjectApplication >(app));
-        _peer1 = homeobj_->our_uuid();
-        _peer2 = boost::uuids::random_generator()();
-
-        auto info = homeobject::PGInfo(_pg_id);
-        info.members.insert(homeobject::PGMember{_peer1, "peer1", 1});
-        info.members.insert(homeobject::PGMember{_peer2, "peer2", 0});
-
-        LOGDEBUG("Setup Pg");
-        EXPECT_TRUE(homeobj_->pg_manager()->create_pg(std::move(info)).get());
-
-        LOGDEBUG("Setup Shards");
-        auto s_e = homeobj_->shard_manager()->create_shard(_pg_id, Mi).get();
-        ASSERT_TRUE(!!s_e);
-        s_e.then([this](auto&& i) { _shard_1 = std::move(i); });
-
-        s_e = homeobj_->shard_manager()->create_shard(_pg_id, Mi).get();
-        ASSERT_TRUE(!!s_e);
-        s_e.then([this](auto&& i) { _shard_2 = std::move(i); });
-
-        LOGDEBUG("Get on empty Shard: {}", _shard_1.id);
-        auto g_e = homeobj_->blob_manager()->get(_shard_1.id, 0).get();
-        ASSERT_FALSE(g_e);
-        EXPECT_EQ(BlobError::UNKNOWN_BLOB, g_e.error());
-
-        LOGDEBUG("Insert Blob to: {}", _shard_1.id);
-        auto o_e = homeobj_->blob_manager()
-                       ->put(_shard_1.id, Blob{sisl::io_blob_safe(4 * Ki, 512u), "test_blob", 4 * Mi})
-                       .get();
-        EXPECT_TRUE(!!o_e);
-        o_e.then([this](auto&& b) mutable { _blob_id = std::move(b); });
-
-        g_e = homeobj_->blob_manager()->get(_shard_1.id, _blob_id).get();
-        EXPECT_TRUE(!!g_e);
-        g_e.then([](auto&& blob) {
-            EXPECT_STREQ(blob.user_key.c_str(), "test_blob");
-            EXPECT_EQ(blob.object_off, 4 * Mi);
-        });
-    }
+    void SetUp() override;
 
 protected:
     std::shared_ptr< homeobject::HomeObject > homeobj_;

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -5,7 +5,7 @@
 
 SISL_LOGGING_INIT(HOMEOBJECT_LOG_MODS)
 
-SISL_OPTIONS_ENABLE(logging, homeobject_options)
+SISL_OPTIONS_ENABLE(logging, homeobject)
 
 class TestApp : public homeobject::HomeObjectApplication {
 public:
@@ -19,7 +19,7 @@ public:
 };
 
 int main(int argc, char** argv) {
-    SISL_OPTIONS_LOAD(argc, argv, logging, homeobject_options)
+    SISL_OPTIONS_LOAD(argc, argv, logging, homeobject)
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T%z] [%^%l%$] [%n] [%t] %v");
 

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,10 +1,11 @@
+#include <folly/init/Init.h>
 #include <sisl/options/options.h>
 #include <homeobject/homeobject.hpp>
 #include <boost/uuid/random_generator.hpp>
 
 SISL_LOGGING_INIT(HOMEOBJECT_LOG_MODS)
 
-SISL_OPTIONS_ENABLE(logging)
+SISL_OPTIONS_ENABLE(logging, homeobject_options)
 
 class TestApp : public homeobject::HomeObjectApplication {
 public:
@@ -18,9 +19,12 @@ public:
 };
 
 int main(int argc, char** argv) {
-    SISL_OPTIONS_LOAD(argc, argv, logging)
+    SISL_OPTIONS_LOAD(argc, argv, logging, homeobject_options)
     sisl::logging::SetLogger(std::string(argv[0]));
     spdlog::set_pattern("[%D %T%z] [%^%l%$] [%n] [%t] %v");
+
+    auto parsed_argc = 1;
+    auto f = ::folly::Init(&parsed_argc, &argv, true);
 
     auto a = std::make_shared< TestApp >();
     homeobject::init_homeobject(a);


### PR DESCRIPTION
The idea is to add another Executor to `iomanager` and make this one of the enumerations HSHomeObject can use which will wrap `run_on`.