### PR TITLE
add select specific chunk interface to heap chunk selector for recovery and GC flow

### DIFF
--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -41,6 +41,10 @@ public:
     void foreach_chunks(std::function< void(csharedChunk&) >&& cb) override;
     csharedChunk select_chunk([[maybe_unused]] homestore::blk_count_t nblks, const homestore::blk_alloc_hints& hints);
 
+    // this function will be used by GC flow or recovery flow to mark one specific chunk to be busy, caller should be
+    // responsible to use release_chunk() interface to release it when no longer to use the chunk anymore.
+    csharedChunk select_specific_chunk(const chunk_num_t);
+
     // this function is used to return a chunk back to ChunkSelector when sealing a shard, and will only be used by
     // Homeobject.
     void release_chunk(const chunk_num_t);


### PR DESCRIPTION
there are some cases we want to mark one specific chunk as busy in heap chunk selector:

1. GC flow which will mark source chunk and dest chunk as busy to prevent more write traffic to these chunks.
2. recovery flow which may replay some create shard journal logs and need to explicitly make allocated chunk as busy