### PR TITLE
Generate blob id from an atomic counter

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -13,6 +13,8 @@ target_link_libraries(${PROJECT_NAME}_core
     ${COMMON_DEPS}
 )
 
+include(${sisl_INCLUDE_DIRS}/../cmake/settings_gen.cmake)
+
 if(BUILD_TESTING)
 add_subdirectory(tests)
 endif()

--- a/src/lib/homeobject_impl.hpp
+++ b/src/lib/homeobject_impl.hpp
@@ -63,7 +63,7 @@ struct PG {
 
     PGInfo pg_info_;
     uint64_t shard_sequence_num_{0};
-    std::atomic_uint64_t blob_sequence_num_{0};
+    std::atomic< blob_id_t > blob_sequence_num_{0ull};
     ShardPtrList shards_;
 };
 

--- a/src/lib/homeobject_impl.hpp
+++ b/src/lib/homeobject_impl.hpp
@@ -63,6 +63,7 @@ struct PG {
 
     PGInfo pg_info_;
     uint64_t shard_sequence_num_{0};
+    std::atomic_uint64_t blob_sequence_num_{0};
     ShardPtrList shards_;
 };
 

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required (VERSION 3.11)
 
+if(NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 add_library ("${PROJECT_NAME}_homestore")
 target_sources("${PROJECT_NAME}_homestore" PRIVATE
     hs_homeobject.cpp

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -15,6 +15,14 @@ target_link_libraries("${PROJECT_NAME}_homestore"
     ${COMMON_DEPS}
 )
 
+set(FLATBUFFERS_FLATC_EXECUTABLE ${flatbuffers_LIB_DIRS}/../bin/flatc)
+settings_gen_cpp(
+    ${FLATBUFFERS_FLATC_EXECUTABLE}
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/
+    "${PROJECT_NAME}_homestore"
+    hs_backend_config.fbs
+  )
+
 if(BUILD_TESTING)
 add_subdirectory(tests)
 

--- a/src/lib/homestore_backend/hs_backend_config.fbs
+++ b/src/lib/homestore_backend/hs_backend_config.fbs
@@ -1,0 +1,14 @@
+native_include "sisl/utility/non_null_ptr.hpp";
+
+namespace homeobjectcfg;
+
+attribute "hotswap";
+attribute "deprecated";
+
+
+table HSBackendSettings {
+    // timer thread freq in us
+    backend_timer_us: uint64 = 60000000 (hotswap);
+}
+
+root_type HSBackendSettings;

--- a/src/lib/homestore_backend/hs_backend_config.hpp
+++ b/src/lib/homestore_backend/hs_backend_config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "common/generated/hs_backend_config_generated.h"
+#include <sisl/settings/settings.hpp>
+#include "generated/hs_backend_config_generated.h"
 
 SETTINGS_INIT(homeobjectcfg::HSBackendSettings, hs_backend_config);
 

--- a/src/lib/homestore_backend/hs_backend_config.hpp
+++ b/src/lib/homestore_backend/hs_backend_config.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "common/generated/hs_backend_config_generated.h"
+
+SETTINGS_INIT(homeobjectcfg::HSBackendSettings, hs_backend_config);
+
+// DM info size depends on these three parameters. If below parameter changes then we have to add
+// the code for upgrade/revert.
+
+namespace homeobject {
+#define HS_BACKEND_DYNAMIC_CONFIG_WITH(...) SETTINGS(hs_backend_config, __VA_ARGS__)
+#define HS_BACKEND_DYNAMIC_CONFIG_THIS(...) SETTINGS_THIS(hs_backend_config, __VA_ARGS__)
+#define HS_BACKEND_DYNAMIC_CONFIG(...) SETTINGS_VALUE(hs_backend_config, __VA_ARGS__)
+
+#define HS_BACKEND_SETTINGS_FACTORY() SETTINGS_FACTORY(hs_backend_config)
+
+} // namespace homeobject

--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -162,7 +162,7 @@ void HSHomeObject::on_blob_put_commit(int64_t lsn, sisl::blob const& header, sis
     auto r = add_to_index_table(index_table, blob_info);
     if (r.hasError()) {
         LOGE("Failed to insert into index table for blob {} err {}", lsn, r.error());
-        ctx->promise_.setValue(folly::makeUnexpected(r.error()));
+        if (ctx) { ctx->promise_.setValue(folly::makeUnexpected(r.error())); }
         return;
     }
 

--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -26,7 +26,7 @@ BlobManager::AsyncResult< blob_id_t > HSHomeObject::_put_blob(ShardInfo const& s
     RELEASE_ASSERT(repl_dev != nullptr, "Repl dev instance null");
 
     const uint32_t needed_size = sizeof(ReplicationMessageHeader);
-    auto req = put_result_ctx< BlobManager::Result< BlobInfo > >::make(needed_size, io_align, new_blob_id);
+    auto req = repl_result_ctx< BlobManager::Result< BlobInfo > >::make(needed_size, io_align);
 
     uint8_t* raw_ptr = req->hdr_buf_.bytes;
     ReplicationMessageHeader* header = new (raw_ptr) ReplicationMessageHeader();
@@ -107,15 +107,21 @@ BlobManager::AsyncResult< blob_id_t > HSHomeObject::_put_blob(ShardInfo const& s
                               (uint8_t*)blob.user_key.data(), blob.user_key.size(), blob_header->hash,
                               BlobHeader::blob_max_hash_len);
 
-    repl_dev->async_alloc_write(req->hdr_buf_, sisl::blob{}, sgs, req);
+    // serialize blob_id as key
+    auto key_blob = sisl::blob(iomanager.iobuf_alloc(sizeof(blob_id_t), io_align), sizeof(blob_id_t));
+    *(reinterpret_cast< blob_id_t* >(key_blob.bytes)) = new_blob_id;
+    // TODO: too many captures in a lambda is not good for performance, find a way to move all the captures to a context
+    // struct
+    repl_dev->async_alloc_write(req->hdr_buf_, key_blob, sgs, req);
     return req->result().deferValue([this, header, blob_header, blob = std::move(blob), blob_bytes, blob_copied,
-                                     user_key_bytes, user_key_copied,
-                                     pad_zeroes](const auto& result) -> BlobManager::AsyncResult< blob_id_t > {
+                                     user_key_bytes, user_key_copied, pad_zeroes,
+                                     key_blob](const auto& result) -> BlobManager::AsyncResult< blob_id_t > {
         header->~ReplicationMessageHeader();
         iomanager.iobuf_free(r_cast< uint8_t* >(blob_header));
         if (blob_copied) { iomanager.iobuf_free(blob_bytes); }
         if (user_key_copied) { iomanager.iobuf_free(r_cast< uint8_t* >(user_key_bytes)); }
         if (pad_zeroes) { iomanager.iobuf_free(r_cast< uint8_t* >(pad_zeroes)); }
+        iomanager.iobuf_free(r_cast< uint8_t* >(key_blob.bytes));
 
         if (result.hasError()) { return folly::makeUnexpected(result.error()); }
         auto blob_info = result.value();
@@ -129,9 +135,9 @@ BlobManager::AsyncResult< blob_id_t > HSHomeObject::_put_blob(ShardInfo const& s
 void HSHomeObject::on_blob_put_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
                                       const homestore::MultiBlkId& pbas,
                                       cintrusive< homestore::repl_req_ctx >& hs_ctx) {
-    put_result_ctx< BlobManager::Result< BlobInfo > >* ctx{nullptr};
+    repl_result_ctx< BlobManager::Result< BlobInfo > >* ctx{nullptr};
     if (hs_ctx != nullptr) {
-        ctx = boost::static_pointer_cast< put_result_ctx< BlobManager::Result< BlobInfo > > >(hs_ctx).get();
+        ctx = boost::static_pointer_cast< repl_result_ctx< BlobManager::Result< BlobInfo > > >(hs_ctx).get();
     }
 
     auto msg_header = r_cast< ReplicationMessageHeader* >(header.bytes);
@@ -141,6 +147,7 @@ void HSHomeObject::on_blob_put_commit(int64_t lsn, sisl::blob const& header, sis
         return;
     }
 
+    auto const blob_id = *(reinterpret_cast< blob_id_t* >(key.bytes));
     shared< BlobIndexTable > index_table;
     {
         std::shared_lock lock_guard(_pg_lock);
@@ -148,14 +155,12 @@ void HSHomeObject::on_blob_put_commit(int64_t lsn, sisl::blob const& header, sis
         RELEASE_ASSERT(iter != _pg_map.end(), "PG not found");
         index_table = static_cast< HS_PG* >(iter->second.get())->index_table_;
         RELEASE_ASSERT(index_table != nullptr, "Index table not intialized");
-        if (iter->second->blob_sequence_num_.load() <= ctx->blob_id_) {
-            iter->second->blob_sequence_num_.store(ctx->blob_id_ + 1);
-        }
+        if (iter->second->blob_sequence_num_.load() <= blob_id) { iter->second->blob_sequence_num_.store(blob_id + 1); }
     }
 
     BlobInfo blob_info;
     blob_info.shard_id = msg_header->shard_id;
-    blob_info.blob_id = ctx->blob_id_;
+    blob_info.blob_id = blob_id;
     blob_info.pbas = pbas;
 
     // Write to index table with key {shard id, blob id } and value {pba}.

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -11,6 +11,7 @@
 #include <homeobject/homeobject.hpp>
 #include "heap_chunk_selector.h"
 #include "index_kv.hpp"
+#include "hs_backend_config.hpp"
 
 namespace homeobject {
 
@@ -24,6 +25,7 @@ extern std::shared_ptr< HomeObject > init_homeobject(std::weak_ptr< HomeObjectAp
     LOGI("Initializing HomeObject");
     auto instance = std::make_shared< HSHomeObject >(std::move(application));
     instance->init_homestore();
+    instance->init_timer_thread();
     return instance;
 }
 
@@ -89,6 +91,37 @@ void HSHomeObject::init_homestore() {
     LOGI("Initialize and start HomeStore is successfully");
 }
 
+void HSHomeObject::init_timer_thread() {
+    struct Context {
+        std::condition_variable cv;
+        std::mutex mtx;
+        bool created{false};
+    };
+    auto ctx = std::make_shared< Context >();
+
+    iomanager.create_reactor("ho_timer_thread", iomgr::INTERRUPT_LOOP, 4u, [&ctx](bool is_started) {
+        if (is_started) {
+            {
+                std::unique_lock< std::mutex > lk{ctx->mtx};
+                ctx->created = true;
+            }
+            ctx->cv.notify_one();
+        }
+    });
+
+    {
+        std::unique_lock< std::mutex > lk{ctx->mtx};
+        ctx->cv.wait(lk, [&ctx] { return ctx->created; });
+    }
+
+    ho_timer_thread_handle_ = iomanager.schedule_global_timer(
+        HS_BACKEND_DYNAMIC_CONFIG(backend_timer_us) * 1000, true /*recurring*/, nullptr /*cookie*/,
+        iomgr::reactor_regex::all_user, [this](void*) { trigger_timed_events(); }, true /* wait_to_schedule */);
+    LOGI("homeobject timer thread started successfully with freq {} usec", HS_BACKEND_DYNAMIC_CONFIG(backend_timer_us));
+}
+
+void HSHomeObject::trigger_timed_events() { persist_pg_sb(); }
+
 void HSHomeObject::register_homestore_metablk_callback() {
     // register some callbacks for metadata recovery;
     using namespace homestore;
@@ -118,6 +151,12 @@ void HSHomeObject::register_homestore_metablk_callback() {
 }
 
 HSHomeObject::~HSHomeObject() {
+    if (ho_timer_thread_handle_.first) {
+        iomanager.cancel_timer(ho_timer_thread_handle_, true);
+        ho_timer_thread_handle_ = iomgr::null_timer_handle;
+    }
+
+    trigger_timed_events();
     homestore::HomeStore::instance()->shutdown();
     homestore::HomeStore::reset_instance();
     iomanager.stop();

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -126,6 +126,7 @@ public:
         HashAlgorithm hash_algorithm;
         uint8_t hash[blob_max_hash_len]{};
         shard_id_t shard_id;
+        blob_id_t blob_id;
         uint32_t blob_size{};
         uint64_t object_offset{};   // Offset of this blob in the object. Provided by GW.
         uint32_t user_key_offset{}; // Offset of metadata stored after the blob data.

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -65,7 +65,7 @@ public:
         uint32_t num_members;
         peer_id_t replica_set_uuid;
         homestore::uuid_t index_table_uuid;
-        uint64_t blob_sequence_num;
+        blob_id_t blob_sequence_num;
         pg_members members[1]; // ISO C++ forbids zero-size array
     };
 

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -33,6 +33,19 @@ struct repl_result_ctx : public ho_repl_ctx {
     folly::SemiFuture< T > result() { return promise_.getSemiFuture(); }
 };
 
+template < typename T >
+struct put_result_ctx : public repl_result_ctx< T > {
+    blob_id_t blob_id_;
+
+    template < typename... Args >
+    static intrusive< put_result_ctx< T > > make(Args&&... args) {
+        return intrusive< put_result_ctx< T > >{new put_result_ctx< T >(std::forward< Args >(args)...)};
+    }
+
+    put_result_ctx(uint32_t hdr_size, uint32_t alignment, blob_id_t const blob_id) :
+            repl_result_ctx< T >{hdr_size, alignment}, blob_id_{blob_id} {}
+};
+
 class ReplicationStateMachine : public homestore::ReplDevListener {
 public:
     explicit ReplicationStateMachine(HSHomeObject* home_object) : home_object_(home_object) {}

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -33,19 +33,6 @@ struct repl_result_ctx : public ho_repl_ctx {
     folly::SemiFuture< T > result() { return promise_.getSemiFuture(); }
 };
 
-template < typename T >
-struct put_result_ctx : public repl_result_ctx< T > {
-    blob_id_t blob_id_;
-
-    template < typename... Args >
-    static intrusive< put_result_ctx< T > > make(Args&&... args) {
-        return intrusive< put_result_ctx< T > >{new put_result_ctx< T >(std::forward< Args >(args)...)};
-    }
-
-    put_result_ctx(uint32_t hdr_size, uint32_t alignment, blob_id_t const blob_id) :
-            repl_result_ctx< T >{hdr_size, alignment}, blob_id_{blob_id} {}
-};
-
 class ReplicationStateMachine : public homestore::ReplDevListener {
 public:
     explicit ReplicationStateMachine(HSHomeObject* home_object) : home_object_(home_object) {}

--- a/src/lib/memory_backend/mem_homeobject.hpp
+++ b/src/lib/memory_backend/mem_homeobject.hpp
@@ -23,7 +23,6 @@ struct BlobExt {
 
 struct ShardIndex {
     folly::ConcurrentHashMap< BlobRoute, BlobExt > btree_;
-    std::atomic< blob_id_t > shard_seq_num_{0ull};
     ~ShardIndex();
 };
 


### PR DESCRIPTION
We maintain a per-PG sequence number and use it to generate a blob id. This sequence number is persisted to pg metablk periodically on an iomgr user reactor by scheduling a global timer. This can be extended to trigger any other timer events in homeobject.

The blob id is generated by the leader during a put blob API and use it as a key for the call `async_alloc_write`

Testing: Added unit test to put blob after restart which will verify the persistence of the blob seq num. 

TODO:

- This PR does not handle the case when we recover from raft snapshot
- As a safety measure, a new raft leader should add a fixed value to his existing sequence number to avoid reusing blob id. 