### PR TITLE
Adopt latest homestore

### DIFF
--- a/src/lib/homestore_backend/index_kv.cpp
+++ b/src/lib/homestore_backend/index_kv.cpp
@@ -44,8 +44,7 @@ BlobManager::NullResult HSHomeObject::add_to_index_table(shared< BlobIndexTable 
                                                          const BlobInfo& blob_info) {
     BlobRouteKey index_key{BlobRoute{blob_info.shard_id, blob_info.blob_id}};
     BlobRouteValue index_value{blob_info.pbas};
-    homestore::BtreeSinglePutRequest put_req{&index_key, &index_value,
-                                             homestore::btree_put_type::INSERT_ONLY_IF_NOT_EXISTS};
+    homestore::BtreeSinglePutRequest put_req{&index_key, &index_value, homestore::btree_put_type::INSERT};
     auto status = index_table->put(put_req);
     if (status != homestore::btree_status_t::success) { return folly::makeUnexpected(BlobError::INDEX_ERROR); }
 
@@ -81,8 +80,7 @@ BlobManager::Result< homestore::MultiBlkId > HSHomeObject::move_to_tombstone(sha
     }
 
     BlobRouteValue index_value_put{tombstone_pbas};
-    homestore::BtreeSinglePutRequest put_req{&index_key, &index_value_put,
-                                             homestore::btree_put_type::REPLACE_ONLY_IF_EXISTS};
+    homestore::BtreeSinglePutRequest put_req{&index_key, &index_value_put, homestore::btree_put_type::UPDATE};
     status = index_table->put(put_req);
     if (status != homestore::btree_status_t::success) {
         LOGDEBUG("Failed to move blob to tombstone in index table [route={}]", index_key);

--- a/src/lib/homestore_backend/index_kv.hpp
+++ b/src/lib/homestore_backend/index_kv.hpp
@@ -19,11 +19,6 @@ public:
     BlobRouteKey(const homestore::BtreeKey& other) : BlobRouteKey(other.serialize(), true) {}
     BlobRouteKey(const sisl::blob& b, bool copy) :
             homestore::BtreeKey(), key_{*(r_cast< const BlobRoute* >(b.bytes))} {}
-    BlobRouteKey& operator=(const BlobRouteKey& other) {
-        clone(other);
-        return *this;
-    };
-    virtual void clone(const homestore::BtreeKey& other) override { key_ = ((BlobRouteKey&)other).key_; }
 
     ~BlobRouteKey() override = default;
 
@@ -46,7 +41,7 @@ public:
 
     void deserialize(const sisl::blob& b, bool copy) override { key_ = *(r_cast< const BlobRoute* >(b.bytes)); }
 
-    static uint32_t get_estimate_max_size() { return get_fixed_size(); }
+    static uint32_t get_max_size() { return get_fixed_size(); }
     friend std::ostream& operator<<(std::ostream& os, const BlobRouteKey& k) {
         os << fmt::format("{}", k.key());
         return os;


### PR DESCRIPTION
some btree_kv interface and enum has been changed in HS in the following PR 
https://github.com/eBay/HomeStore/pull/211

this PR adopts the latest HS. CI will success until this PR is merged 
https://github.com/eBay/HomeStore/pull/228