### PR TITLE
Issue #107 #119: HomeObject to report Per PG stats and Per-HomeObject Stats

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -40,8 +40,7 @@ class HomeObjectConan(ConanFile):
         self.build_requires("gtest/1.14.0")
 
     def requirements(self):
-        #self.requires("homestore/[~=4,      include_prerelease=True]@oss/master")
-        self.requires("homestore/4.9.1@yakuang/oss")
+        self.requires("homestore/[~=4,      include_prerelease=True]@oss/master")
         self.requires("sisl/[~=10,          include_prerelease=True]@oss/master")
         self.requires("lz4/1.9.4", override=True)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "0.13.1"
+    version = "0.14.1"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,8 @@ class HomeObjectConan(ConanFile):
         self.build_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("homestore/[~=4,      include_prerelease=True]@oss/master")
+        #self.requires("homestore/[~=4,      include_prerelease=True]@oss/master")
+        self.requires("homestore/4.9.1@yakuang/oss")
         self.requires("sisl/[~=10,          include_prerelease=True]@oss/master")
         self.requires("lz4/1.9.4", override=True)
 

--- a/src/include/homeobject/homeobject.hpp
+++ b/src/include/homeobject/homeobject.hpp
@@ -28,6 +28,17 @@ public:
     virtual std::string lookup_peer(peer_id_t const&) const = 0;
 };
 
+struct HomeObjectStats {
+    uint64_t total_capacity_bytes{0};
+    uint64_t used_capacity_bytes{0};
+    uint32_t num_open_shards{0};
+    uint32_t avail_open_shards{0};
+    std::string to_string() const {
+        return fmt::format("total_capacity_bytes={}, used_capacity_bytes={}, num_open_shards={}, avail_open_shards={}",
+                           total_capacity_bytes, used_capacity_bytes, num_open_shards, avail_open_shards);
+    }
+};
+
 class HomeObject {
 public:
     virtual ~HomeObject() = default;
@@ -35,6 +46,7 @@ public:
     virtual std::shared_ptr< BlobManager > blob_manager() = 0;
     virtual std::shared_ptr< PGManager > pg_manager() = 0;
     virtual std::shared_ptr< ShardManager > shard_manager() = 0;
+    virtual HomeObjectStats get_stats() const = 0;
 };
 
 extern std::shared_ptr< HomeObject > init_homeobject(std::weak_ptr< HomeObjectApplication >&& application);

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -40,12 +40,12 @@ struct PGInfo {
 struct PGStats {
     pg_id_t id;
     peer_id_t replica_set_uuid;
-    uint32_t num_members;           // number of members in this PG;
-    uint32_t total_shards;          // shards allocated on this PG (including open shards)
-    uint32_t open_shards;           // active shards on this PG;
-    uint32_t available_open_shards; // total number of shards that could be opened on this PG;
-    uint64_t used_bytes;            // total number of bytes used by all shards on this PG;
-    uint64_t avail_bytes;           // total number of bytes available on this PG;
+    uint32_t num_members;       // number of members in this PG;
+    uint32_t total_shards;      // shards allocated on this PG (including open shards)
+    uint32_t open_shards;       // active shards on this PG;
+    uint32_t avail_open_shards; // total number of shards that could be opened on this PG;
+    uint64_t used_bytes;        // total number of bytes used by all shards on this PG;
+    uint64_t avail_bytes;       // total number of bytes available on this PG;
 };
 
 class PGManager : public Manager< PGError > {

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -46,14 +46,15 @@ struct PGStats {
     uint32_t avail_open_shards; // total number of shards that could be opened on this PG;
     uint64_t used_bytes;        // total number of bytes used by all shards on this PG;
     uint64_t avail_bytes;       // total number of bytes available on this PG;
-    std::vector< std::pair< peer_id_t, std::string > > members;
+    std::vector< std::tuple< peer_id_t, std::string, uint64_t /* last_commit_lsn */ > > members;
 
     std::string to_string() {
         std::string members_str;
         uint32_t i = 0ul;
         for (auto const& m : members) {
             if (i++ > 0) { members_str += ", "; };
-            members_str += fmt::format("member-{}: id={}, name={}", i, boost::uuids::to_string(m.first), m.second);
+            members_str += fmt::format("member-{}: id={}, name={}, last_commit_lsn={}", i,
+                                       boost::uuids::to_string(std::get< 0 >(m)), std::get< 1 >(m), std::get< 2 >(m));
         }
 
         return fmt::format("PGStats: id={}, replica_set_uuid={}, num_members={}, total_shards={}, open_shards={}, "

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -46,12 +46,20 @@ struct PGStats {
     uint32_t avail_open_shards; // total number of shards that could be opened on this PG;
     uint64_t used_bytes;        // total number of bytes used by all shards on this PG;
     uint64_t avail_bytes;       // total number of bytes available on this PG;
+    std::vector< std::pair< peer_id_t, std::string > > members;
 
     std::string to_string() {
+        std::string members_str;
+        uint32_t i = 0ul;
+        for (auto const& m : members) {
+            if (i++ > 0) { members_str += ", "; };
+            members_str += fmt::format("member-{}: id={}, name={}", i, boost::uuids::to_string(m.first), m.second);
+        }
+
         return fmt::format("PGStats: id={}, replica_set_uuid={}, num_members={}, total_shards={}, open_shards={}, "
-                           "avail_open_shards={}, used_bytes={}, avail_bytes={}",
+                           "avail_open_shards={}, used_bytes={}, avail_bytes={}, members: {}",
                            id, boost::uuids::to_string(replica_set_uuid), num_members, total_shards, open_shards,
-                           avail_open_shards, used_bytes, avail_bytes);
+                           avail_open_shards, used_bytes, avail_bytes, members_str);
     }
 };
 

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -37,10 +37,39 @@ struct PGInfo {
     auto operator==(PGInfo const& rhs) const { return id == rhs.id; }
 };
 
+struct PGStats {
+    pg_id_t id;
+    peer_id_t replica_set_uuid;
+    uint32_t num_members;           // number of members in this PG;
+    uint32_t total_shards;          // shards allocated on this PG (including open shards)
+    uint32_t open_shards;           // active shards on this PG;
+    uint32_t available_open_shards; // total number of shards that could be opened on this PG;
+    uint64_t used_bytes;            // total number of bytes used by all shards on this PG;
+    uint64_t avail_bytes;           // total number of bytes available on this PG;
+};
+
 class PGManager : public Manager< PGError > {
 public:
     virtual NullAsyncResult create_pg(PGInfo&& pg_info) = 0;
     virtual NullAsyncResult replace_member(pg_id_t id, peer_id_t const& old_member, PGMember const& new_member) = 0;
+
+    /**
+     * Retrieves the statistics for a specific PG (Placement Group) identified by its ID.
+     *
+     * @param id The ID of the PG.
+     * @param stats The reference to the PGStats object where the statistics will be stored.
+     * @return True if the statistics were successfully retrieved, false otherwise (e.g. id not found).
+     */
+    virtual bool get_stats(pg_id_t id, PGStats& stats) = 0;
+
+    /**
+     * @brief Retrieves the list of pg_ids.
+     *
+     * This function retrieves the list of pg_ids and stores them in the provided vector.
+     *
+     * @param pg_ids The vector to store the pg_ids.
+     */
+    virtual void get_pg_ids(std::vector< pg_id_t >& pg_ids) = 0;
 };
 
 } // namespace homeobject

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -46,6 +46,13 @@ struct PGStats {
     uint32_t avail_open_shards; // total number of shards that could be opened on this PG;
     uint64_t used_bytes;        // total number of bytes used by all shards on this PG;
     uint64_t avail_bytes;       // total number of bytes available on this PG;
+
+    std::string to_string() {
+        return fmt::format("PGStats: id={}, replica_set_uuid={}, num_members={}, total_shards={}, open_shards={}, "
+                           "avail_open_shards={}, used_bytes={}, avail_bytes={}",
+                           id, boost::uuids::to_string(replica_set_uuid), num_members, total_shards, open_shards,
+                           avail_open_shards, used_bytes, avail_bytes);
+    }
 };
 
 class PGManager : public Manager< PGError > {

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -67,7 +67,7 @@ public:
      * @param stats The reference to the PGStats object where the statistics will be stored.
      * @return True if the statistics were successfully retrieved, false otherwise (e.g. id not found).
      */
-    virtual bool get_stats(pg_id_t id, PGStats& stats) = 0;
+    virtual bool get_stats(pg_id_t id, PGStats& stats) const = 0;
 
     /**
      * @brief Retrieves the list of pg_ids.
@@ -76,7 +76,7 @@ public:
      *
      * @param pg_ids The vector to store the pg_ids.
      */
-    virtual void get_pg_ids(std::vector< pg_id_t >& pg_ids) = 0;
+    virtual void get_pg_ids(std::vector< pg_id_t >& pg_ids) const = 0;
 };
 
 } // namespace homeobject

--- a/src/include/homeobject/shard_manager.hpp
+++ b/src/include/homeobject/shard_manager.hpp
@@ -31,6 +31,7 @@ struct ShardInfo {
 
     auto operator<=>(ShardInfo const& rhs) const { return id <=> rhs.id; }
     auto operator==(ShardInfo const& rhs) const { return id == rhs.id; }
+    bool is_open() { return state == State::OPEN; }
 };
 
 using InfoList = std::list< ShardInfo >;

--- a/src/lib/homeobject_impl.cpp
+++ b/src/lib/homeobject_impl.cpp
@@ -13,8 +13,8 @@ HomeObjectImpl::HomeObjectImpl(std::weak_ptr< HomeObjectApplication >&& applicat
     auto exe_type = SISL_OPTIONS["executor"].as< std::string >();
     std::transform(exe_type.begin(), exe_type.end(), exe_type.begin(), ::tolower);
 
-    if ("immediate" == exe_type) [[likely]]
-        executor_ = &folly::QueuedImmediateExecutor::instance();
+    if ("immediate" == exe_type)
+        [[likely]] executor_ = &folly::QueuedImmediateExecutor::instance();
     else if ("io" == exe_type)
         executor_ = folly::getGlobalIOExecutor();
     else if ("cpu" == exe_type)
@@ -23,5 +23,4 @@ HomeObjectImpl::HomeObjectImpl(std::weak_ptr< HomeObjectApplication >&& applicat
         RELEASE_ASSERT(false, "Unknown Folly Executor type: [{}]", exe_type);
     LOGI("initialized with [executor={}]", exe_type);
 }
-
 } // namespace homeobject

--- a/src/lib/homeobject_impl.hpp
+++ b/src/lib/homeobject_impl.hpp
@@ -85,8 +85,10 @@ class HomeObjectImpl : public HomeObject,
     virtual PGManager::NullAsyncResult _create_pg(PGInfo&& pg_info, std::set< std::string, std::less<> > peers) = 0;
     virtual PGManager::NullAsyncResult _replace_member(pg_id_t id, peer_id_t const& old_member,
                                                        PGMember const& new_member) = 0;
-    virtual bool _get_stats(pg_id_t id, PGStats& stats) = 0;
-    virtual void _get_pg_ids(std::vector< pg_id_t >& pg_ids) = 0;
+    virtual bool _get_stats(pg_id_t id, PGStats& stats) const = 0;
+    virtual void _get_pg_ids(std::vector< pg_id_t >& pg_ids) const = 0;
+
+    virtual HomeObjectStats _get_stats() const = 0;
 
 protected:
     std::mutex _repl_lock;
@@ -121,15 +123,18 @@ public:
     std::shared_ptr< PGManager > pg_manager() final;
     std::shared_ptr< ShardManager > shard_manager() final;
 
+    /// HomeObject
+    /// Returns the UUID of this HomeObject.
     peer_id_t our_uuid() const final { return _our_id; }
+    HomeObjectStats get_stats() const final { return _get_stats(); }
 
     /// PgManager
     PGManager::NullAsyncResult create_pg(PGInfo&& pg_info) final;
     PGManager::NullAsyncResult replace_member(pg_id_t id, peer_id_t const& old_member,
                                               PGMember const& new_member) final;
     // see api comments in base class;
-    bool get_stats(pg_id_t id, PGStats& stats) final;
-    void get_pg_ids(std::vector< pg_id_t >& pg_ids) final;
+    bool get_stats(pg_id_t id, PGStats& stats) const final;
+    void get_pg_ids(std::vector< pg_id_t >& pg_ids) const final;
 
     /// ShardManager
     ShardManager::AsyncResult< ShardInfo > get_shard(shard_id_t id) const final;

--- a/src/lib/homeobject_impl.hpp
+++ b/src/lib/homeobject_impl.hpp
@@ -45,6 +45,7 @@ struct Shard {
     explicit Shard(ShardInfo info) : info(std::move(info)) {}
     virtual ~Shard() = default;
     ShardInfo info;
+    bool is_open() { return ShardInfo::State::OPEN == info.state; }
 };
 
 using ShardPtr = unique< Shard >;

--- a/src/lib/homeobject_impl.hpp
+++ b/src/lib/homeobject_impl.hpp
@@ -4,7 +4,6 @@
 #include "homeobject/blob_manager.hpp"
 #include "homeobject/pg_manager.hpp"
 #include "homeobject/shard_manager.hpp"
-
 #include <sisl/logging/logging.h>
 
 #define LOGT(...) LOGTRACEMOD(homeobject, ##__VA_ARGS__)
@@ -34,7 +33,6 @@ using intrusive = boost::intrusive_ptr< T >;
 
 template < typename T >
 using cintrusive = const boost::intrusive_ptr< T >;
-
 constexpr size_t pg_width = sizeof(pg_id_t) * 8;
 constexpr size_t shard_width = (sizeof(shard_id_t) * 8) - pg_width;
 constexpr size_t shard_mask = std::numeric_limits< homeobject::shard_id_t >::max() >> pg_width;
@@ -86,6 +84,8 @@ class HomeObjectImpl : public HomeObject,
     virtual PGManager::NullAsyncResult _create_pg(PGInfo&& pg_info, std::set< std::string, std::less<> > peers) = 0;
     virtual PGManager::NullAsyncResult _replace_member(pg_id_t id, peer_id_t const& old_member,
                                                        PGMember const& new_member) = 0;
+    virtual bool _get_stats(pg_id_t id, PGStats& stats) = 0;
+    virtual void _get_pg_ids(std::vector< pg_id_t >& pg_ids) = 0;
 
 protected:
     std::mutex _repl_lock;
@@ -126,6 +126,9 @@ public:
     PGManager::NullAsyncResult create_pg(PGInfo&& pg_info) final;
     PGManager::NullAsyncResult replace_member(pg_id_t id, peer_id_t const& old_member,
                                               PGMember const& new_member) final;
+    // see api comments in base class;
+    bool get_stats(pg_id_t id, PGStats& stats) final;
+    void get_pg_ids(std::vector< pg_id_t >& pg_ids) final;
 
     /// ShardManager
     ShardManager::AsyncResult< ShardInfo > get_shard(shard_id_t id) const final;

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -187,6 +187,8 @@ uint32_t HeapChunkSelector::most_available_num_chunks() const {
     return max_avail_num_chunks;
 }
 
+uint32_t HeapChunkSelector::total_chunks() const { return m_chunks.size(); }
+
 uint64_t HeapChunkSelector::avail_blks(std::optional< uint32_t > dev_it) const {
     if (!dev_it.has_value()) {
         uint64_t max_avail_blks = 0ull;

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -19,25 +19,32 @@ namespace homeobject {
 // this should only be called when initializing HeapChunkSelector in Homestore
 void HeapChunkSelector::add_chunk(csharedChunk& chunk) { m_chunks.emplace(VChunk(chunk).get_chunk_id(), chunk); }
 
-void HeapChunkSelector::add_chunk_internal(const chunk_num_t chunkID) {
+void HeapChunkSelector::add_chunk_internal(const chunk_num_t chunkID, bool add_to_heap) {
     if (m_chunks.find(chunkID) == m_chunks.end()) {
         // sanity check
         LOGWARNMOD(homeobject, "No chunk found for ChunkID {}", chunkID);
         return;
     }
+
     const auto& chunk = m_chunks[chunkID];
     VChunk vchunk(chunk);
     auto pdevID = vchunk.get_pdev_id();
     // add this find here, since we don`t want to call make_shared in try_emplace every time.
     auto it = m_per_dev_heap.find(pdevID);
-    if (it == m_per_dev_heap.end()) it = m_per_dev_heap.emplace(pdevID, std::make_shared< PerDevHeap >()).first;
-    auto& avalableBlkCounter = it->second->available_blk_count;
-    avalableBlkCounter.fetch_add(vchunk.available_blks());
+    if (it == m_per_dev_heap.end()) { it = m_per_dev_heap.emplace(pdevID, std::make_shared< PerDevHeap >()).first; }
 
-    auto& heapLock = it->second->mtx;
-    auto& heap = it->second->m_heap;
-    std::lock_guard< std::mutex > l(heapLock);
-    heap.emplace(chunk);
+    // build total blks for every chunk on this device;
+    it->second->m_total_blks += vchunk.get_total_blks();
+
+    if (add_to_heap) {
+        auto& avalableBlkCounter = it->second->available_blk_count;
+        avalableBlkCounter.fetch_add(vchunk.available_blks());
+
+        auto& heapLock = it->second->mtx;
+        auto& heap = it->second->m_heap;
+        std::lock_guard< std::mutex > l(heapLock);
+        heap.emplace(chunk);
+    }
 }
 
 // select_chunk will only be called in homestore when creating a shard.
@@ -153,7 +160,9 @@ void HeapChunkSelector::release_chunk(const chunk_num_t chunkID) {
 
 void HeapChunkSelector::build_per_dev_chunk_heap(const std::unordered_set< chunk_num_t >& excludingChunks) {
     for (const auto& p : m_chunks) {
-        if (excludingChunks.find(p.first) == excludingChunks.end()) { add_chunk_internal(p.first); }
+        bool add_to_heap = true;
+        if (excludingChunks.find(p.first) == excludingChunks.end()) { add_to_heap = false; }
+        add_chunk_internal(p.first, add_to_heap);
     };
 }
 
@@ -168,4 +177,32 @@ homestore::blk_alloc_hints HeapChunkSelector::chunk_to_hints(chunk_num_t chunk_i
     return hints;
 }
 
+// return the maximum number of chunks that can be allocated on pdev
+uint32_t HeapChunkSelector::most_available_num_chunks() const {
+    uint32_t max_avail_num_chunks = 0ul;
+    for (auto const& [_, pdev_heap] : m_per_dev_heap) {
+        max_avail_num_chunks = std::max(max_avail_num_chunks, pdev_heap->size());
+    }
+
+    return max_avail_num_chunks;
+}
+
+uint64_t HeapChunkSelector::avail_blks(std::optional< uint32_t > dev_it) const {
+    if (!dev_it.has_value()) {
+        uint64_t max_avail_blks = 0ull;
+        for (auto const& [_, heap] : m_per_dev_heap) {
+            std::scoped_lock lock(heap->mtx);
+            max_avail_blks = std::max(max_avail_blks, static_cast< uint64_t >(heap->available_blk_count.load()));
+        }
+        return max_avail_blks;
+    } else {
+        auto it = m_per_dev_heap.find(dev_it.value());
+        std::scoped_lock lock(it->second->mtx);
+        if (it == m_per_dev_heap.end()) {
+            LOGWARNMOD(homeobject, "No pdev found for pdev {}", dev_it.value());
+            return 0;
+        }
+        return it->second->available_blk_count.load();
+    }
+}
 } // namespace homeobject

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -34,7 +34,7 @@ void HeapChunkSelector::add_chunk_internal(const chunk_num_t chunkID, bool add_t
     if (it == m_per_dev_heap.end()) { it = m_per_dev_heap.emplace(pdevID, std::make_shared< PerDevHeap >()).first; }
 
     // build total blks for every chunk on this device;
-    it->second->m_total_blks += vchunk.get_total_blks();
+    // it->second->m_total_blks += vchunk.get_total_blks();
 
     if (add_to_heap) {
         auto& avalableBlkCounter = it->second->available_blk_count;
@@ -161,7 +161,7 @@ void HeapChunkSelector::release_chunk(const chunk_num_t chunkID) {
 void HeapChunkSelector::build_per_dev_chunk_heap(const std::unordered_set< chunk_num_t >& excludingChunks) {
     for (const auto& p : m_chunks) {
         bool add_to_heap = true;
-        if (excludingChunks.find(p.first) == excludingChunks.end()) { add_to_heap = false; }
+        if (excludingChunks.find(p.first) != excludingChunks.end()) { add_to_heap = false; }
         add_chunk_internal(p.first, add_to_heap);
     };
 }
@@ -205,4 +205,15 @@ uint64_t HeapChunkSelector::avail_blks(std::optional< uint32_t > dev_it) const {
         return it->second->available_blk_count.load();
     }
 }
+
+uint64_t HeapChunkSelector::total_blks(uint32_t dev_id) const {
+    auto it = m_per_dev_heap.find(dev_id);
+    if (it == m_per_dev_heap.end()) {
+        LOGWARNMOD(homeobject, "No pdev found for pdev {}", dev_id);
+        return 0;
+    }
+
+    return it->second->m_total_blks;
+}
+
 } // namespace homeobject

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -42,6 +42,10 @@ void HeapChunkSelector::add_chunk_internal(const chunk_num_t chunkID, bool add_t
 
         auto& heapLock = it->second->mtx;
         auto& heap = it->second->m_heap;
+        {
+            std::lock_guard< std::mutex > l(m_defrag_mtx);
+            m_defrag_heap.emplace(chunk);
+        }
         std::lock_guard< std::mutex > l(heapLock);
         heap.emplace(chunk);
     }

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -216,13 +216,23 @@ homestore::blk_alloc_hints HeapChunkSelector::chunk_to_hints(chunk_num_t chunk_i
 }
 
 // return the maximum number of chunks that can be allocated on pdev
-uint32_t HeapChunkSelector::most_available_num_chunks() const {
+uint32_t HeapChunkSelector::most_avail_num_chunks() const {
     uint32_t max_avail_num_chunks = 0ul;
     for (auto const& [_, pdev_heap] : m_per_dev_heap) {
         max_avail_num_chunks = std::max(max_avail_num_chunks, pdev_heap->size());
     }
 
     return max_avail_num_chunks;
+}
+
+uint32_t HeapChunkSelector::avail_num_chunks(uint32_t dev_id) const {
+    auto it = m_per_dev_heap.find(dev_id);
+    if (it == m_per_dev_heap.end()) {
+        LOGWARNMOD(homeobject, "No pdev found for pdev {}", dev_id);
+        return 0;
+    }
+
+    return it->second->size();
 }
 
 uint32_t HeapChunkSelector::total_chunks() const { return m_chunks.size(); }

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -34,7 +34,7 @@ void HeapChunkSelector::add_chunk_internal(const chunk_num_t chunkID, bool add_t
     if (it == m_per_dev_heap.end()) { it = m_per_dev_heap.emplace(pdevID, std::make_shared< PerDevHeap >()).first; }
 
     // build total blks for every chunk on this device;
-    // it->second->m_total_blks += vchunk.get_total_blks();
+    it->second->m_total_blks += vchunk.get_total_blks();
 
     if (add_to_heap) {
         auto& avalableBlkCounter = it->second->available_blk_count;

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -93,7 +93,15 @@ public:
      *
      * @return The number of available chunks.
      */
-    uint32_t most_available_num_chunks() const;
+    uint32_t most_avail_num_chunks() const;
+
+    /**
+     * Returns the number of available chunks for a given device ID.
+     *
+     * @param dev_id The device ID.
+     * @return The number of available chunks.
+     */
+    uint32_t avail_num_chunks(uint32_t dev_id) const;
 
     /**
      * @brief Returns the total number of chunks.

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -35,6 +35,8 @@ public:
         std::mutex mtx;
         VChunkHeap m_heap;
         std::atomic_size_t available_blk_count;
+        uint64_t m_total_blks{0}; // initlized during boot, and will not change during runtime;
+        uint32_t size() const { return m_heap.size(); }
     };
 
     void add_chunk(csharedChunk&) override;
@@ -52,7 +54,29 @@ public:
     // this should be called after ShardManager is initialized and get all the open shards
     void build_per_dev_chunk_heap(const std::unordered_set< chunk_num_t >& excludingChunks);
 
+    /**
+     * Retrieves the block allocation hints for a given chunk.
+     *
+     * @param chunk_id The ID of the chunk.
+     * @return The block allocation hints for the specified chunk.
+     */
     homestore::blk_alloc_hints chunk_to_hints(chunk_num_t chunk_id) const;
+
+    /**
+     * Returns the number of available blocks of the given device id.
+     *
+     * @param dev_id (optional) The device ID. if nullopt, it returns the maximum available blocks among all devices.
+     * @return The number of available blocks.
+     */
+    uint64_t avail_blks(std::optional< uint32_t > dev_id) const;
+
+    /**
+     * Returns the maximum number of chunks on pdev that are currently available for allocation.
+     * Caller is not interested with the pdev id;
+     *
+     * @return The number of available chunks.
+     */
+    uint32_t most_available_num_chunks() const;
 
 private:
     std::unordered_map< uint32_t, std::shared_ptr< PerDevHeap > > m_per_dev_heap;
@@ -60,6 +84,6 @@ private:
     // hold all the chunks , selected or not
     std::unordered_map< chunk_num_t, csharedChunk > m_chunks;
 
-    void add_chunk_internal(const chunk_num_t);
+    void add_chunk_internal(const chunk_num_t, bool add_to_heap = true);
 };
 } // namespace homeobject

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -86,6 +86,15 @@ public:
      */
     uint32_t most_available_num_chunks() const;
 
+    /**
+     * @brief Returns the total number of chunks.
+     *
+     * This function returns the total number of chunks in the heap chunk selector.
+     *
+     * @return The total number of chunks.
+     */
+    uint32_t total_chunks() const;
+
 private:
     std::unordered_map< uint32_t, std::shared_ptr< PerDevHeap > > m_per_dev_heap;
 

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -71,6 +71,14 @@ public:
     uint64_t avail_blks(std::optional< uint32_t > dev_id) const;
 
     /**
+     * Returns the total number of blocks of the given device;
+     *
+     * @param dev_id The device ID.
+     * @return The total number of blocks.
+     */
+    uint64_t total_blks(uint32_t dev_id) const;
+
+    /**
      * Returns the maximum number of chunks on pdev that are currently available for allocation.
      * Caller is not interested with the pdev id;
      *

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -152,7 +152,7 @@ HSHomeObject::~HSHomeObject() {
 }
 
 void HSHomeObject::on_shard_meta_blk_found(homestore::meta_blk* mblk, sisl::byte_view buf) {
-    homestore::superblk< shard_info_superblk > sb;
+    homestore::superblk< shard_info_superblk > sb(_shard_meta_name);
     sb.load(buf, mblk);
     add_new_shard_to_map(std::make_unique< HS_Shard >(sb));
 }

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -43,8 +43,10 @@ class HSHomeObject : public HomeObjectImpl {
     PGManager::NullAsyncResult _replace_member(pg_id_t id, peer_id_t const& old_member,
                                                PGMember const& new_member) override;
 
-    bool _get_stats(pg_id_t id, PGStats& stats) override;
-    void _get_pg_ids(std::vector< pg_id_t >& pg_ids) override;
+    bool _get_stats(pg_id_t id, PGStats& stats) const override;
+    void _get_pg_ids(std::vector< pg_id_t >& pg_ids) const override;
+
+    HomeObjectStats _get_stats() const override;
 
     // Mapping from index table uuid to pg id.
     std::shared_mutex index_lock_;
@@ -221,7 +223,7 @@ public:
 
     std::optional< homestore::chunk_num_t > get_any_chunk_id(pg_id_t const pg);
 
-    shared< HeapChunkSelector > chunk_selector() { return chunk_selector_; }
+    cshared< HeapChunkSelector > chunk_selector() const { return chunk_selector_; }
 
     bool on_pre_commit_shard_msg(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
                                  cintrusive< homestore::repl_req_ctx >&);

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -109,7 +109,7 @@ public:
         /**
          * Returns the number of open shards on this PG.
          */
-        uint32_t open_shards(std::vector< homestore::chunk_num_t >&) const;
+        uint32_t open_shards() const;
 
         /**
          * Retrieves the device hint associated with this PG(if any shard is created).

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -206,7 +206,7 @@ void HSHomeObject::persist_pg_sb() {
     }
 }
 
-bool HSHomeObject::_get_stats(pg_id_t id, PGStats& stats) {
+bool HSHomeObject::_get_stats(pg_id_t id, PGStats& stats) const {
     auto lg = std::shared_lock(_pg_lock);
     auto it = _pg_map.find(id);
     if (_pg_map.end() == it) { return false; }
@@ -263,7 +263,7 @@ bool HSHomeObject::_get_stats(pg_id_t id, PGStats& stats) {
     return true;
 }
 
-void HSHomeObject::_get_pg_ids(std::vector< pg_id_t >& pg_ids) {
+void HSHomeObject::_get_pg_ids(std::vector< pg_id_t >& pg_ids) const {
     {
         auto lg = std::shared_lock(_pg_lock);
         for (auto& [id, _] : _pg_map) {

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -220,6 +220,10 @@ bool HSHomeObject::_get_stats(pg_id_t id, PGStats& stats) const {
     stats.total_shards = hs_pg->total_shards();
     stats.open_shards = hs_pg->open_shards();
 
+    for (auto const& m : hs_pg->pg_info_.members) {
+        stats.members.emplace_back(m.id, m.name);
+    }
+
     auto const pdev_id_hint = hs_pg->dev_hint(chunk_selector());
     if (pdev_id_hint.has_value()) {
         auto total_chunks_on_dev = 0ul;

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -221,7 +221,8 @@ bool HSHomeObject::_get_stats(pg_id_t id, PGStats& stats) const {
     stats.open_shards = hs_pg->open_shards();
 
     for (auto const& m : hs_pg->pg_info_.members) {
-        stats.members.emplace_back(m.id, m.name);
+        // TODO: get last commit lsn from repl_dev when it is ready;
+        stats.members.emplace_back(std::make_tuple(m.id, m.name, 0 /* last commit lsn */));
     }
 
     auto const pdev_id_hint = hs_pg->dev_hint(chunk_selector());

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -124,7 +124,7 @@ PGInfo HSHomeObject::deserialize_pg_info(std::string const& json_str) {
 #endif
 
 void HSHomeObject::on_pg_meta_blk_found(sisl::byte_view const& buf, void* meta_cookie) {
-    homestore::superblk< pg_info_superblk > pg_sb;
+    homestore::superblk< pg_info_superblk > pg_sb(_pg_meta_name);
     pg_sb.load(buf, meta_cookie);
 
     hs_repl_service()

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -285,3 +285,52 @@ TEST_F(HomeObjectFixture, SealShardWithRestart) {
     ASSERT_EQ(b.error(), BlobError::SEALED_SHARD);
     LOGINFO("Put blob {}", b.error());
 }
+
+TEST_F(HomeObjectFixture, PGStatsTest) {
+    // Create a pg, shard, put blob should succeed.
+    pg_id_t pg_id{1};
+    create_pg(pg_id);
+
+    auto s = _obj_inst->shard_manager()->create_shard(pg_id, 64 * Mi).get();
+    ASSERT_TRUE(!!s);
+    auto shard_info = s.value();
+    auto shard_id = shard_info.id;
+    s = _obj_inst->shard_manager()->get_shard(shard_id).get();
+    ASSERT_TRUE(!!s);
+
+    LOGINFO("Got shard {}", shard_id);
+    shard_info = s.value();
+    EXPECT_EQ(shard_info.id, shard_id);
+    EXPECT_EQ(shard_info.placement_group, pg_id);
+    EXPECT_EQ(shard_info.state, ShardInfo::State::OPEN);
+    auto b = _obj_inst->blob_manager()->put(shard_id, Blob{sisl::io_blob_safe(512u, 512u), "test_blob", 0ul}).get();
+    ASSERT_TRUE(!!b);
+    LOGINFO("Put blob {}", b.value());
+
+    // create a shard
+    s = _obj_inst->shard_manager()->seal_shard(shard_id).get();
+    ASSERT_TRUE(!!s);
+    shard_info = s.value();
+    EXPECT_EQ(shard_info.id, shard_id);
+    EXPECT_EQ(shard_info.placement_group, pg_id);
+    EXPECT_EQ(shard_info.state, ShardInfo::State::SEALED);
+    LOGINFO("Sealed shard {}", shard_id);
+
+    // create a 2nd shard
+    auto s2 = _obj_inst->shard_manager()->create_shard(pg_id, 64 * Mi).get();
+    auto shard_info2 = s2.value();
+    auto shard_id2 = shard_info2.id;
+    s2 = _obj_inst->shard_manager()->get_shard(shard_id2).get();
+    ASSERT_TRUE(!!s);
+    LOGINFO("Got shard {}", shard_id2);
+
+    PGStats pg_stats;
+    auto res = _obj_inst->pg_manager()->get_stats(pg_id, pg_stats);
+    LOGINFO("stats: {}", pg_stats.to_string());
+
+    EXPECT_EQ(res, true);
+    EXPECT_EQ(pg_stats.id, pg_id);
+    EXPECT_EQ(pg_stats.total_shards, 2);
+    EXPECT_EQ(pg_stats.open_shards, 1);
+    EXPECT_EQ(pg_stats.num_members, 3);
+}

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -333,4 +333,7 @@ TEST_F(HomeObjectFixture, PGStatsTest) {
     EXPECT_EQ(pg_stats.total_shards, 2);
     EXPECT_EQ(pg_stats.open_shards, 1);
     EXPECT_EQ(pg_stats.num_members, 3);
+
+    auto stats = _obj_inst->get_stats();
+    LOGINFO("HomeObj stats: {}", stats.to_string());
 }

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -12,7 +12,12 @@ SISL_LOGGING_INIT(logging, HOMEOBJECT_LOG_MODS)
 SISL_OPTIONS_ENABLE(logging)
 
 namespace homestore {
+// This is a fake implementation of Chunk/VChunk to avoid linking with homestore instance.
 
+// if redefinition error was seen while building this file, any api being added in homestore::Chunk/VChunk, also needs
+// to add one here to avoid redefinition error.
+// Compiler will get confused if symbol can't be resolved locally(e.g. in this file), and will try to find it in
+// homestore library which will cause redefine error.
 class Chunk : public std::enable_shared_from_this< Chunk > {
 public:
     uint32_t available_blks() const { return m_available_blks; }
@@ -25,6 +30,7 @@ public:
 
     uint16_t get_chunk_id() const { return m_chunk_id; }
 
+    blk_num_t get_total_blks() const { return 0; }
     void set_chunk_id(uint16_t chunk_id) { m_chunk_id = chunk_id; }
     const std::shared_ptr< Chunk > get_internal_chunk() { return shared_from_this(); }
 
@@ -51,6 +57,8 @@ blk_num_t VChunk::available_blks() const { return m_internal_chunk->available_bl
 uint32_t VChunk::get_pdev_id() const { return m_internal_chunk->get_pdev_id(); }
 
 uint16_t VChunk::get_chunk_id() const { return m_internal_chunk->get_chunk_id(); }
+
+blk_num_t VChunk::get_total_blks() const { return m_internal_chunk->get_total_blks(); }
 
 cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk->get_internal_chunk(); }
 

--- a/src/lib/memory_backend/mem_homeobject.hpp
+++ b/src/lib/memory_backend/mem_homeobject.hpp
@@ -49,8 +49,10 @@ class MemoryHomeObject : public HomeObjectImpl {
     PGManager::NullAsyncResult _replace_member(pg_id_t id, peer_id_t const& old_member,
                                                PGMember const& new_member) override;
 
-    bool _get_stats(pg_id_t id, PGStats& stats) override;
-    void _get_pg_ids(std::vector< pg_id_t >& pg_ids) override;
+    bool _get_stats(pg_id_t id, PGStats& stats) const override;
+    void _get_pg_ids(std::vector< pg_id_t >& pg_ids) const override;
+
+    HomeObjectStats _get_stats() const override;
 
     ShardIndex& _find_index(shard_id_t) const;
 

--- a/src/lib/memory_backend/mem_homeobject.hpp
+++ b/src/lib/memory_backend/mem_homeobject.hpp
@@ -49,6 +49,9 @@ class MemoryHomeObject : public HomeObjectImpl {
     PGManager::NullAsyncResult _replace_member(pg_id_t id, peer_id_t const& old_member,
                                                PGMember const& new_member) override;
 
+    bool _get_stats(pg_id_t id, PGStats& stats) override;
+    void _get_pg_ids(std::vector< pg_id_t >& pg_ids) override;
+
     ShardIndex& _find_index(shard_id_t) const;
 
 public:

--- a/src/lib/memory_backend/mem_pg_manager.cpp
+++ b/src/lib/memory_backend/mem_pg_manager.cpp
@@ -13,8 +13,9 @@ PGManager::NullAsyncResult MemoryHomeObject::_replace_member(pg_id_t id, peer_id
     return folly::makeSemiFuture< PGManager::NullResult >(folly::makeUnexpected(PGError::UNSUPPORTED_OP));
 }
 
-bool MemoryHomeObject::_get_stats(pg_id_t id, PGStats& stats) { RELEASE_ASSERT(false, "Not implemented!"); }
+bool MemoryHomeObject::_get_stats(pg_id_t id, PGStats& stats) const { RELEASE_ASSERT(false, "Not implemented!"); }
 
-void MemoryHomeObject::_get_pg_ids(std::vector< pg_id_t >& pg_ids) { RELEASE_ASSERT(false, "Not implemented!"); }
+void MemoryHomeObject::_get_pg_ids(std::vector< pg_id_t >& pg_ids) const { RELEASE_ASSERT(false, "Not implemented!"); }
 
+HomeObjectStats MemoryHomeObject::_get_stats() const { RELEASE_ASSERT(false, "Not implemented!"); }
 } // namespace homeobject

--- a/src/lib/memory_backend/mem_pg_manager.cpp
+++ b/src/lib/memory_backend/mem_pg_manager.cpp
@@ -12,4 +12,9 @@ PGManager::NullAsyncResult MemoryHomeObject::_replace_member(pg_id_t id, peer_id
                                                              PGMember const& new_member) {
     return folly::makeSemiFuture< PGManager::NullResult >(folly::makeUnexpected(PGError::UNSUPPORTED_OP));
 }
+
+bool MemoryHomeObject::_get_stats(pg_id_t id, PGStats& stats) { RELEASE_ASSERT(false, "Not implemented!"); }
+
+void MemoryHomeObject::_get_pg_ids(std::vector< pg_id_t >& pg_ids) { RELEASE_ASSERT(false, "Not implemented!"); }
+
 } // namespace homeobject

--- a/src/lib/pg_manager.cpp
+++ b/src/lib/pg_manager.cpp
@@ -35,4 +35,7 @@ PGManager::NullAsyncResult HomeObjectImpl::replace_member(pg_id_t id, peer_id_t 
 
     return _replace_member(id, old_member, new_member);
 }
+
+bool HomeObjectImpl::get_stats(pg_id_t id, PGStats& stats) { return _get_stats(id, stats); }
+void HomeObjectImpl::get_pg_ids(std::vector< pg_id_t >& pg_ids) { return _get_pg_ids(pg_ids); }
 } // namespace homeobject

--- a/src/lib/pg_manager.cpp
+++ b/src/lib/pg_manager.cpp
@@ -36,6 +36,6 @@ PGManager::NullAsyncResult HomeObjectImpl::replace_member(pg_id_t id, peer_id_t 
     return _replace_member(id, old_member, new_member);
 }
 
-bool HomeObjectImpl::get_stats(pg_id_t id, PGStats& stats) { return _get_stats(id, stats); }
-void HomeObjectImpl::get_pg_ids(std::vector< pg_id_t >& pg_ids) { return _get_pg_ids(pg_ids); }
+bool HomeObjectImpl::get_stats(pg_id_t id, PGStats& stats) const { return _get_stats(id, stats); }
+void HomeObjectImpl::get_pg_ids(std::vector< pg_id_t >& pg_ids) const { return _get_pg_ids(pg_ids); }
 } // namespace homeobject


### PR DESCRIPTION
Add per PG stats according to: https://github.corp.ebay.com/SDS/nuobject_proto/pull/10

This PR will need homestore PR: https://github.com/eBay/HomeStore/pull/243/files

A new test case added for PGstats and HomeObj stats


Test:
====
```
[12/05/23 11:26:27.953] [./bin/homestore_test] [info] [82978] [hs_blob_tests.cpp:329:TestBody] stats: PGStats: id=1, replica_set_uuid=3524160a-c694-4120-9a1c-4a7626e561c2, 
num_members=3, total_shards=2, open_shards=1, avail_open_shards=127, used_bytes=26402816, avail_bytes=1676314624, 
members: 
member-1: id=9efb16ac-964d-4bc7-883c-9f8bb363839c, name=peer1, 
member-2: id=82008433-de79-4c89-bdb5-71356cb849ae, name=peer3, 
member-3: id=a75534a5-6d20-42e3-9bdc-eaa826682d2d, name=peer2
[12/04/23 12:28:17.833] [./bin/homestore_test] [info] [80734] [hs_blob_tests.cpp:338:TestBody] HomeObj stats: total_capacity_bytes=1689518080, used_capacity_bytes=5120, num_open_shards=1, avail_open_shards=127
```
