### PR TITLE
We use a std::optional to indicate no uuid read.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -6,7 +6,12 @@ pipeline {
         CONAN_USER = 'oss'
         TARGET_BRANCH = 'main'
         STABLE_BRANCH = 'stable/v*'
-        DISABLE_DEP_TESTS = '-o sisl:testing=False -o iomgr:testing=off -o homestore:testing=off'
+        built_chain = ''
+        failed_pkg = ''
+    }
+
+    parameters {
+        string(defaultValue: "", description: 'UpstreamTriggered', name: 'upstream_triggered')
     }
 
     stages {
@@ -55,9 +60,9 @@ pipeline {
 
         stage("Compile") {
             steps {
-                sh """conan create ${BUILD_MISSING} ${DISABLE_DEP_TESTS} -o ${PROJECT}:sanitize=True -pr debug . ${PROJECT}/${TAG} ;
-                      conan create ${BUILD_MISSING} ${DISABLE_DEP_TESTS} -pr debug . ${PROJECT}/${TAG} ;
-                      conan create ${BUILD_MISSING} ${DISABLE_DEP_TESTS} -pr test . ${PROJECT}/${TAG} ;"""
+                sh """conan create ${BUILD_MISSING} -o ${PROJECT}:sanitize=True -pr debug . ${PROJECT}/${TAG} ;
+                      conan create ${BUILD_MISSING} -pr debug . ${PROJECT}/${TAG} ;
+                      conan create ${BUILD_MISSING} -pr test . ${PROJECT}/${TAG} ;"""
             }
         }
 
@@ -70,11 +75,36 @@ pipeline {
                 sh "conan upload ${PROJECT}/${TAG} -c --all -r ebay-local"
             }
         }
+        stage("Downstream Build") {
+            when { allOf {
+               expression { (env.BRANCH_NAME == "${TARGET_BRANCH}") }
+               expression { (!"${upstream_triggered}") || ("${upstream_triggered}" == "") }
+            } }
+        
+            stages {
+                stage('StorageManager') {
+                    steps {
+                        script {
+                            def hobj_res = build job: "StorageManager/main", parameters: [[$class: 'StringParameterValue', name: 'upstream_triggered', value: 'true']], propagate: true
+                            built_chain = "${built_chain}" + ", " + "$hobj_res.buildVariables.pkg_version"
+                        }
+                    }
+                    post {
+                        failure { script { failed_pkg = "StorageManager" } }
+                    }
+                }
+            }
+        }
     }
 
     post {
         failure {
-            slackSend color: '#E43237', channel: '#sds-ci', message: "*${PROJECT}/${TAG}* has had a failure : ${BUILD_URL}"
+            script {
+                if ("${failed_pkg}" != "") {
+                    slackSend color: '#E43237', channel: '#sds-ci', message: "@here HomeObject downstream pkg - *${failed_pkg}* build failed.\n*URL:* ${BUILD_URL}\nIf result not expected, revert (aka `conan remove -r ebay-local`) these pkgs: ```${built_chain}```"
+                } else {
+                    slackSend color: '#E43237', channel: '#sds-ci', message: "*${PROJECT}/${TAG}* has had a failure : ${BUILD_URL}"
+            }
         }
         success {
             slackSend color: '#85B717', channel: '#sds-ci', message: "*${PROJECT}/${TAG}* has completed."

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "0.14.1"
+    version = "0.14.2"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -1,5 +1,6 @@
 
 #include <latch>
+#include <optional>
 #include <spdlog/fmt/bin_to_hex.h>
 
 #include <homestore/homestore.hpp>
@@ -61,7 +62,7 @@ void HSHomeObject::init_homestore() {
 
     // We either recoverd a UUID and no FORMAT is needed, or we need one for a later superblock
     if (need_format) {
-        _our_id = _application.lock()->discover_svcid(boost::uuids::uuid());
+        _our_id = _application.lock()->discover_svcid(std::nullopt);
         RELEASE_ASSERT(!_our_id.is_nil(), "Received no SvcId and need FORMAT!");
         LOGW("We are starting for the first time on [{}], Formatting!!", to_string(_our_id));
 

--- a/src/lib/memory_backend/mem_homeobject.cpp
+++ b/src/lib/memory_backend/mem_homeobject.cpp
@@ -9,7 +9,7 @@ extern std::shared_ptr< HomeObject > init_homeobject(std::weak_ptr< HomeObjectAp
 
 MemoryHomeObject::MemoryHomeObject(std::weak_ptr< HomeObjectApplication >&& application) :
         HomeObjectImpl::HomeObjectImpl(std::move(application)) {
-    _our_id = _application.lock()->discover_svcid(_our_id);
+    _our_id = _application.lock()->discover_svcid(std::nullopt);
 }
 
 ShardIndex::~ShardIndex() {

--- a/src/lib/tests/fixture_app.cpp
+++ b/src/lib/tests/fixture_app.cpp
@@ -24,8 +24,7 @@ FixtureApp::FixtureApp() {
 }
 
 homeobject::peer_id_t FixtureApp::discover_svcid(std::optional< homeobject::peer_id_t > const& p) const {
-    auto const& new_id = p.value();
-    return new_id.is_nil() ? boost::uuids::random_generator()() : new_id;
+    return p.has_value() ? p.value() : boost::uuids::random_generator()();
 }
 
 void TestFixture::SetUp() {


### PR DESCRIPTION
These changes are needed for the StorageManager to be built-automatically in CI and to properly use the std::optional in the public API for UUID discovery.