### PR TITLE
replicate createpg message across raft group

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "1.0.4"
+    version = "1.0.5"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -9,7 +9,8 @@
 
 namespace homeobject {
 
-ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, UNKNOWN_PEER, UNSUPPORTED_OP);
+ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, UNKNOWN_PEER, UNSUPPORTED_OP, PG_ALREADY_EXISTS,
+     CRC_MISMATCH);
 
 struct PGMember {
     explicit PGMember(peer_id_t _id) : id(_id) {}

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -9,7 +9,8 @@
 
 namespace homeobject {
 
-ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, UNKNOWN_PEER, UNSUPPORTED_OP, CRC_MISMATCH);
+ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, UNKNOWN_PEER, UNSUPPORTED_OP, CRC_MISMATCH,
+     NO_SPACE_LEFT, DRIVE_WRITE_ERROR);
 
 struct PGMember {
     explicit PGMember(peer_id_t _id) : id(_id) {}

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -9,8 +9,7 @@
 
 namespace homeobject {
 
-ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, UNKNOWN_PEER, UNSUPPORTED_OP, PG_ALREADY_EXISTS,
-     CRC_MISMATCH);
+ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, UNKNOWN_PEER, UNSUPPORTED_OP, CRC_MISMATCH);
 
 struct PGMember {
     explicit PGMember(peer_id_t _id) : id(_id) {}

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -126,8 +126,9 @@ void HSHomeObject::init_homestore() {
 
         HomeStore::instance()->format_and_start({
             {HS_SERVICE::META, hs_format_params{.size_pct = 5.0}},
-            {HS_SERVICE::LOG_REPLICATED, hs_format_params{.size_pct = 10.0}},
-            {HS_SERVICE::LOG_LOCAL, hs_format_params{.size_pct = 0.1}}, // TODO: Remove this after HS disables LOG_LOCAL
+            {HS_SERVICE::LOG_REPLICATED, hs_format_params{.size_pct = 10.0, .chunk_size = 32 * Mi}},
+            {HS_SERVICE::LOG_LOCAL,
+             hs_format_params{.size_pct = 0.1, .chunk_size = 32 * Mi}}, // TODO: Remove this after HS disables LOG_LOCAL
             {HS_SERVICE::REPLICATION,
              hs_format_params{.size_pct = 79.0,
                               .num_chunks = 65000,

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -126,9 +126,7 @@ void HSHomeObject::init_homestore() {
 
         HomeStore::instance()->format_and_start({
             {HS_SERVICE::META, hs_format_params{.size_pct = 5.0}},
-            {HS_SERVICE::LOG_REPLICATED, hs_format_params{.size_pct = 10.0, .chunk_size = 32 * Mi}},
-            {HS_SERVICE::LOG_LOCAL,
-             hs_format_params{.size_pct = 0.1, .chunk_size = 32 * Mi}}, // TODO: Remove this after HS disables LOG_LOCAL
+            {HS_SERVICE::LOG, hs_format_params{.size_pct = 10.0, .chunk_size = 32 * Mi}},
             {HS_SERVICE::REPLICATION,
              hs_format_params{.size_pct = 79.0,
                               .num_chunks = 65000,

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -220,7 +220,7 @@ private:
     static homestore::ReplicationService& hs_repl_service() { return homestore::hs()->repl_service(); }
 
     // create pg related
-    PGManager::NullAsyncResult replicate_create_pg_msg(cshared< homestore::ReplDev > repl_dev, PGInfo&& pg_info);
+    PGManager::NullAsyncResult do_create_pg(cshared< homestore::ReplDev > repl_dev, PGInfo&& pg_info);
     static std::string serialize_pg_info(const PGInfo& info);
     static PGInfo deserialize_pg_info(const char* pg_info_str, size_t size);
     void add_pg_to_map(unique< HS_PG > hs_pg);

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -219,7 +219,15 @@ private:
 private:
     static homestore::ReplicationService& hs_repl_service() { return homestore::hs()->repl_service(); }
 
+    // create pg related
+    PGManager::NullAsyncResult replicate_create_pg_msg(cshared< homestore::ReplDev > repl_dev, PGInfo&& pg_info);
+    static std::string serialize_pg_info(const PGInfo& info);
+    static PGInfo deserialize_pg_info(const char* pg_info_str, size_t size);
     void add_pg_to_map(unique< HS_PG > hs_pg);
+    void do_create_pg_message_commit(int64_t lsn, ReplicationMessageHeader& header, homestore::MultiBlkId const& blkids,
+                                     sisl::blob value, cintrusive< homestore::repl_req_ctx >& hs_ctx);
+
+    // create shard related
     shard_id_t generate_new_shard_id(pg_id_t pg);
     uint64_t get_sequence_num_from_shard_id(uint64_t shard_id_t);
 
@@ -259,6 +267,18 @@ public:
      *
      */
     void init_cp();
+
+    /**
+     * @brief Callback function invoked when createPG message is committed on a shard.
+     *
+     * @param lsn The logical sequence number of the message.
+     * @param header The header of the message.
+     * @param blkids The IDs of the blocks associated with the message.
+     * @param repl_dev The replication device.
+     * @param hs_ctx The replication request context.
+     */
+    void on_create_pg_message_commit(int64_t lsn, sisl::blob const& header, homestore::MultiBlkId const& blkids,
+                                     homestore::ReplDev* repl_dev, cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     /**
      * @brief Callback function invoked when a message is committed on a shard.

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -222,10 +222,8 @@ private:
     // create pg related
     PGManager::NullAsyncResult do_create_pg(cshared< homestore::ReplDev > repl_dev, PGInfo&& pg_info);
     static std::string serialize_pg_info(const PGInfo& info);
-    static PGInfo deserialize_pg_info(const char* pg_info_str, size_t size);
+    static PGInfo deserialize_pg_info(const unsigned char* pg_info_str, size_t size);
     void add_pg_to_map(unique< HS_PG > hs_pg);
-    void do_create_pg_message_commit(int64_t lsn, ReplicationMessageHeader& header, homestore::MultiBlkId const& blkids,
-                                     sisl::blob value, cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     // create shard related
     shard_id_t generate_new_shard_id(pg_id_t pg);
@@ -273,12 +271,11 @@ public:
      *
      * @param lsn The logical sequence number of the message.
      * @param header The header of the message.
-     * @param blkids The IDs of the blocks associated with the message.
      * @param repl_dev The replication device.
      * @param hs_ctx The replication request context.
      */
-    void on_create_pg_message_commit(int64_t lsn, sisl::blob const& header, homestore::MultiBlkId const& blkids,
-                                     homestore::ReplDev* repl_dev, cintrusive< homestore::repl_req_ctx >& hs_ctx);
+    void on_create_pg_message_commit(int64_t lsn, sisl::blob const& header, shared< homestore::ReplDev > repl_dev,
+                                     cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     /**
      * @brief Callback function invoked when a message is committed on a shard.
@@ -290,7 +287,7 @@ public:
      * @param hs_ctx The replication request context.
      */
     void on_shard_message_commit(int64_t lsn, sisl::blob const& header, homestore::MultiBlkId const& blkids,
-                                 homestore::ReplDev* repl_dev, cintrusive< homestore::repl_req_ctx >& hs_ctx);
+                                 shared< homestore::ReplDev > repl_dev, cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     /**
      * @brief Retrieves the chunk number associated with the given shard ID.

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -36,6 +36,10 @@ PGError toPgError(ReplServiceError const& e) {
         return PGError::TIMEOUT;
     case ReplServiceError::SERVER_NOT_FOUND:
         return PGError::UNKNOWN_PG;
+    case ReplServiceError::NO_SPACE_LEFT:
+        return PGError::NO_SPACE_LEFT;
+    case ReplServiceError::DRIVE_WRITE_ERROR:
+        return PGError::DRIVE_WRITE_ERROR;
     /* TODO: enable this after add erro type to homestore
     case ReplServiceError::CRC_MISMATCH:
         return PGError::CRC_MISMATCH;

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -129,11 +129,7 @@ void HSHomeObject::do_create_pg_message_commit(int64_t lsn, ReplicationMessageHe
                                                homestore::MultiBlkId const& blkids, sisl::blob value,
                                                cintrusive< homestore::repl_req_ctx >& hs_ctx) {
     repl_result_ctx< PGManager::NullResult >* ctx{nullptr};
-    // if this is a follower, the promise_ of hs_ctx will be nullptr, so need to setValue.
-    // but we can not judge whether this is leader from hs_ctx directly at this time.
-    // since repl_req_ctx::value is only applicable for leader, so we take it as a criteria to determine
-    // it is a leader or not.
-    if (hs_ctx && hs_ctx->value.size > 0) {
+    if (hs_ctx && hs_ctx->is_proposer) {
         ctx = boost::static_pointer_cast< repl_result_ctx< PGManager::NullResult > >(hs_ctx).get();
     }
 

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -64,6 +64,8 @@ PGManager::NullAsyncResult HSHomeObject::_create_pg(PGInfo&& pg_info, std::set< 
             if (v.hasError()) { return folly::makeUnexpected(toPgError(v.error())); }
             // we will write a PGHeader across the raft group and when it is committed
             // all raft members will create PGinfo and index table for this PG.
+
+            // FIXME:https://github.com/eBay/HomeObject/pull/136#discussion_r1470504271
             return do_create_pg(v.value(), std::move(pg_info));
         });
 }

--- a/src/lib/homestore_backend/hs_shard_manager.cpp
+++ b/src/lib/homestore_backend/hs_shard_manager.cpp
@@ -143,7 +143,7 @@ ShardManager::AsyncResult< ShardInfo > HSHomeObject::_seal_shard(ShardInfo const
 }
 
 void HSHomeObject::on_shard_message_commit(int64_t lsn, sisl::blob const& header, homestore::MultiBlkId const& blkids,
-                                           homestore::ReplDev* repl_dev,
+                                           shared< homestore::ReplDev > repl_dev,
                                            cintrusive< homestore::repl_req_ctx >& hs_ctx) {
 
     if (hs_ctx != nullptr) {

--- a/src/lib/homestore_backend/hs_shard_manager.cpp
+++ b/src/lib/homestore_backend/hs_shard_manager.cpp
@@ -179,11 +179,7 @@ void HSHomeObject::do_shard_message_commit(int64_t lsn, ReplicationMessageHeader
                                            homestore::MultiBlkId const& blkids, sisl::blob value,
                                            cintrusive< homestore::repl_req_ctx >& hs_ctx) {
     repl_result_ctx< ShardManager::Result< ShardInfo > >* ctx{nullptr};
-    // if this is a follower, the promise_ of hs_ctx will be nullptr, so need to setValue.
-    // but we can not judge whether this is leader from hs_ctx directly at this time.
-    // since repl_req_ctx::value is only applicable for leader, so we take it as a criteria to determine
-    // it is a leader or not.
-    if (hs_ctx && hs_ctx->value.size > 0) {
+    if (hs_ctx && hs_ctx->is_proposer) {
         ctx = boost::static_pointer_cast< repl_result_ctx< ShardManager::Result< ShardInfo > > >(hs_ctx).get();
     }
 

--- a/src/lib/homestore_backend/replication_message.hpp
+++ b/src/lib/homestore_backend/replication_message.hpp
@@ -7,8 +7,8 @@
 
 namespace homeobject {
 
-VENUM(ReplicationMessageType, uint16_t, CREATE_SHARD_MSG = 0, SEAL_SHARD_MSG = 1, PUT_BLOB_MSG = 2, DEL_BLOB_MSG = 3,
-      UNKNOWN_MSG = 4);
+VENUM(ReplicationMessageType, uint16_t, CREATE_PG_MSG = 0, CREATE_SHARD_MSG = 1, SEAL_SHARD_MSG = 2, PUT_BLOB_MSG = 3,
+      DEL_BLOB_MSG = 4, UNKNOWN_MSG = 5);
 
 // magic num comes from the first 8 bytes of 'echo homeobject_replication | md5sum'
 static constexpr uint64_t HOMEOBJECT_REPLICATION_MAGIC = 0x11153ca24efc8d34;

--- a/src/lib/homestore_backend/replication_message.hpp
+++ b/src/lib/homestore_backend/replication_message.hpp
@@ -20,8 +20,8 @@ struct ReplicationMessageHeader {
     uint64_t magic_num{HOMEOBJECT_REPLICATION_MAGIC};
     uint32_t protocol_version{HOMEOBJECT_REPLICATION_PROTOCOL_VERSION_V1};
     ReplicationMessageType msg_type; // message type
-    pg_id_t pg_id;
-    shard_id_t shard_id;
+    pg_id_t pg_id{0};
+    shard_id_t shard_id{0};
     uint32_t payload_size;
     uint32_t payload_crc;
     uint8_t reserved_pad[4]{};

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -7,6 +7,10 @@ void ReplicationStateMachine::on_commit(int64_t lsn, const sisl::blob& header, c
     LOGI("applying raft log commit with lsn:{}", lsn);
     const ReplicationMessageHeader* msg_header = r_cast< const ReplicationMessageHeader* >(header.cbytes());
     switch (msg_header->msg_type) {
+    case ReplicationMessageType::CREATE_PG_MSG: {
+        home_object_->on_create_pg_message_commit(lsn, header, pbas, repl_dev(), ctx);
+        break;
+    }
     case ReplicationMessageType::CREATE_SHARD_MSG:
     case ReplicationMessageType::SEAL_SHARD_MSG: {
         home_object_->on_shard_message_commit(lsn, header, pbas, repl_dev(), ctx);

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -44,6 +44,12 @@ void ReplicationStateMachine::on_rollback(int64_t lsn, sisl::blob const&, sisl::
     LOGI("on_rollback  with lsn:{}", lsn);
 }
 
+void ReplicationStateMachine::on_error(ReplServiceError error, const sisl::blob& header, const sisl::blob& key,
+                                       cintrusive< repl_req_ctx >& ctx) {
+    LOGE("on_error  with :{}, lsn {}", error, ctx->lsn);
+    // TODO:: block is already freeed at homestore side, handle error if necessay.
+}
+
 homestore::blk_alloc_hints ReplicationStateMachine::get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size) {
     const ReplicationMessageHeader* msg_header = r_cast< const ReplicationMessageHeader* >(header.cbytes());
     switch (msg_header->msg_type) {

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -8,7 +8,7 @@ void ReplicationStateMachine::on_commit(int64_t lsn, const sisl::blob& header, c
     const ReplicationMessageHeader* msg_header = r_cast< const ReplicationMessageHeader* >(header.cbytes());
     switch (msg_header->msg_type) {
     case ReplicationMessageType::CREATE_PG_MSG: {
-        home_object_->on_create_pg_message_commit(lsn, header, pbas, repl_dev(), ctx);
+        home_object_->on_create_pg_message_commit(lsn, header, repl_dev(), ctx);
         break;
     }
     case ReplicationMessageType::CREATE_SHARD_MSG:

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -8,6 +8,8 @@
 namespace homeobject {
 
 class HSHomeObject;
+using homestore::repl_req_ctx;
+using homestore::ReplServiceError;
 
 struct ho_repl_ctx : public homestore::repl_req_ctx {
     ReplicationMessageHeader header_;
@@ -91,6 +93,19 @@ public:
     /// @param ctx - User contenxt passed as part of the replica_set::write() api
     void on_rollback(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                      cintrusive< homestore::repl_req_ctx >& ctx) override;
+
+    /// @brief Called when the async_alloc_write call failed to initiate replication
+    ///
+    /// Called only on the node which called async_alloc_write
+    ///
+    ///
+    /// NOTE: Listener should do the free any resources created as part of pre-commit.
+    ///
+    /// @param header - Header originally passed with ReplDev::async_alloc_write() api
+    /// @param key - Key originally passed with ReplDev::async_alloc_write() api
+    /// @param ctx - Context passed as part of the ReplDev::async_alloc_write() api
+    void on_error(ReplServiceError error, const sisl::blob& header, const sisl::blob& key,
+                  cintrusive< repl_req_ctx >& ctx);
 
     /// @brief Called when replication module is trying to allocate a block to write the value
     ///

--- a/src/lib/homestore_backend/tests/hs_shard_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_shard_tests.cpp
@@ -108,7 +108,7 @@ TEST_F(TestFixture, MockSealShard) {
     sisl::sg_list value;
     value.size = msg_size;
     value.iovs.push_back(iovec(buf_ptr, msg_size));
-    repl_dev->async_alloc_write(header, sisl::blob{}, value, req);
+    repl_dev->async_alloc_write(header, sisl::blob{buf_ptr, (uint32_t)msg_size}, value, req);
     auto info = req->result().get();
     EXPECT_TRUE(info);
     EXPECT_TRUE(info.value().id == shard_info.id);


### PR DESCRIPTION
we need to replicate create PG message across the rafte group, so that the follower can create pginfo and index table. 