### PR TITLE
enable restartability for homeobject

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "1.0.6"
+    version = "1.0.7"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -59,6 +59,8 @@ class HSHomeObject : public HomeObjectImpl {
         std::shared_ptr< BlobIndexTable > index_table;
     };
     std::unordered_map< std::string, PgIndexTable > index_table_pg_map_;
+    std::vector< std::pair< sisl::byte_view, void* > > m_pg_sb_bufs;
+    std::vector< std::pair< sisl::byte_view, void* > > m_shard_sb_bufs;
 
 public:
 #pragma pack(1)
@@ -243,9 +245,9 @@ private:
 
     // recover part
     void register_homestore_metablk_callback();
-    void on_pg_meta_blk_found(sisl::byte_view const& buf, void* meta_cookie);
-    void on_shard_meta_blk_found(homestore::meta_blk* mblk, sisl::byte_view buf);
-    void on_shard_meta_blk_recover_completed(bool success);
+    void initialize_chunk_selector();
+    void recover_pg();
+    void recover_shard();
 
     void persist_pg_sb();
 

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -192,28 +192,31 @@ PGInfo HSHomeObject::deserialize_pg_info(const unsigned char* json_str, size_t s
     return pg_info;
 }
 
-void HSHomeObject::on_pg_meta_blk_found(sisl::byte_view const& buf, void* meta_cookie) {
-    homestore::superblk< pg_info_superblk > pg_sb(_pg_meta_name);
-    pg_sb.load(buf, meta_cookie);
+void HSHomeObject::recover_pg() {
+    for (auto const& [buf, mblk] : m_pg_sb_bufs) {
+        homestore::superblk< pg_info_superblk > pg_sb(_pg_meta_name);
+        pg_sb.load(buf, mblk);
 
-    auto v = hs_repl_service().get_repl_dev(pg_sb->replica_set_uuid);
-    if (v.hasError()) {
-        // TODO: We need to raise an alert here, since without pg repl_dev all operations on that pg will fail
-        LOGE("open_repl_dev for group_id={} has failed", boost::uuids::to_string(pg_sb->replica_set_uuid));
-        return;
+        auto v = hs_repl_service().get_repl_dev(pg_sb->replica_set_uuid);
+        if (v.hasError()) {
+            // TODO: We need to raise an alert here, since without pg repl_dev all operations on that pg will fail
+            LOGE("open_repl_dev for group_id={} has failed", boost::uuids::to_string(pg_sb->replica_set_uuid));
+            return;
+        }
+        auto pg_id = pg_sb->id;
+        auto uuid_str = boost::uuids::to_string(pg_sb->index_table_uuid);
+        auto hs_pg = std::make_unique< HS_PG >(std::move(pg_sb), std::move(v.value()));
+        // During PG recovery check if index is already recoverd else
+        // add entry in map, so that index recovery can update the PG.
+        std::scoped_lock lg(index_lock_);
+        auto it = index_table_pg_map_.find(uuid_str);
+        RELEASE_ASSERT(it != index_table_pg_map_.end(), "IndexTable should be recovered before PG");
+        hs_pg->index_table_ = it->second.index_table;
+        it->second.pg_id = pg_id;
+
+        add_pg_to_map(std::move(hs_pg));
     }
-    auto pg_id = pg_sb->id;
-    auto uuid_str = boost::uuids::to_string(pg_sb->index_table_uuid);
-    auto hs_pg = std::make_unique< HS_PG >(std::move(pg_sb), std::move(v.value()));
-    // During PG recovery check if index is already recoverd else
-    // add entry in map, so that index recovery can update the PG.
-    std::scoped_lock lg(index_lock_);
-    auto it = index_table_pg_map_.find(uuid_str);
-    RELEASE_ASSERT(it != index_table_pg_map_.end(), "IndexTable should be recovered before PG");
-    hs_pg->index_table_ = it->second.index_table;
-    it->second.pg_id = pg_id;
-
-    add_pg_to_map(std::move(hs_pg));
+    m_pg_sb_bufs.clear();
 }
 
 PGInfo HSHomeObject::HS_PG::pg_info_from_sb(homestore::superblk< pg_info_superblk > const& sb) {

--- a/src/lib/homestore_backend/hs_shard_manager.cpp
+++ b/src/lib/homestore_backend/hs_shard_manager.cpp
@@ -239,6 +239,15 @@ void HSHomeObject::on_shard_message_commit(int64_t lsn, sisl::blob const& h, hom
     }
 }
 
+void HSHomeObject::recover_shard() {
+    for (auto& [buf, mblk] : m_shard_sb_bufs) {
+        homestore::superblk< shard_info_superblk > sb(_shard_meta_name);
+        sb.load(buf, mblk);
+        add_new_shard_to_map(std::make_unique< HS_Shard >(std::move(sb)));
+    }
+    m_shard_sb_bufs.clear();
+}
+
 void HSHomeObject::add_new_shard_to_map(ShardPtr&& shard) {
     // TODO: We are taking a global lock for all pgs to create shard. Is it really needed??
     // We need to have fine grained per PG lock and take only that.

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -46,7 +46,7 @@ TEST_F(HomeObjectFixture, BasicPutGetDelBlobWRestart) {
     trigger_cp(true /* wait */);
 
     // Restart homeobject
-    // restart();
+    restart();
 
     // Verify all get blobs after restart
     verify_get_blob(blob_map);
@@ -101,7 +101,7 @@ TEST_F(HomeObjectFixture, BasicPutGetDelBlobWRestart) {
     trigger_cp(true /* wait */);
 
     // Restart homeobject
-    // restart();
+    restart();
 
     // After restart, for all deleted blobs, get should fail
     for (const auto& [id, blob] : blob_map) {
@@ -147,7 +147,7 @@ TEST_F(HomeObjectFixture, SealShardWithRestart) {
     LOGINFO("Put blob {}", b.error());
 
     // Restart homeobject
-    // restart();
+    restart();
 
     // Verify shard is sealed.
     s = _obj_inst->shard_manager()->get_shard(shard_id).get();

--- a/src/lib/tests/fixture_app.cpp
+++ b/src/lib/tests/fixture_app.cpp
@@ -18,7 +18,7 @@ SISL_OPTIONS_ENABLE(logging, homeobject, test_home_object)
 
 FixtureApp::FixtureApp() {
     clean();
-    LOGWARN("creating device {} file with size {} ", path_, 2 * Gi);
+    LOGWARN("creating device {} file with size {} ", path_, 10 * Gi);
     std::ofstream ofs{path_, std::ios::binary | std::ios::out | std::ios::trunc};
     std::filesystem::resize_file(path_, 10 * Gi);
 }


### PR DESCRIPTION
since we have restartability in homestore, enable the restartability in homeobject now

in the current implementation , when restarting, repl_dev will not be loaded when restarting meta service, it will be postponed to the the start of raft_repl_service. but when restarting, Pg is recovered when restarting metaservice , which will get the repl_dev from raft_repl_service, this causes an error.