### PR TITLE
UT improvement

### DIFF
--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -295,6 +295,7 @@ homestore::blk_alloc_hints HSHomeObject::blob_put_get_blk_alloc_hints(sisl::blob
 }
 
 BlobManager::NullAsyncResult HSHomeObject::_del_blob(ShardInfo const& shard, blob_id_t blob_id) {
+    BLOGT(shard.id, blob_id, "deleting blob");
     auto& pg_id = shard.placement_group;
     shared< homestore::ReplDev > repl_dev;
     {


### PR DESCRIPTION
The delete blob test is actually deleting those blobs from putBlob, with racing with putBlobs (as we run async) and other thread(as all threads are using same blobID range for deletion).  Each deleteBlob should either success or fail with unknownBlob.

Previously we access the e.error() with out checkout !!e (success).

When success , e is folly::unit() and accessing e.error() will causing SIGABRT.

This is the reason that the UT should not pass but was pasing in the past. It is very unlikely all deleteBlob get executed before putBlob.