### PR TITLE
Reject put_blob with zero length.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "1.0.14"
+    version = "1.0.15"
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
     topics = ("ebay")

--- a/src/lib/blob_manager.cpp
+++ b/src/lib/blob_manager.cpp
@@ -17,6 +17,7 @@ BlobManager::AsyncResult< blob_id_t > HomeObjectImpl::put(shard_id_t shard, Blob
         [this, blob = std::move(blob)](auto const e) mutable -> BlobManager::AsyncResult< blob_id_t > {
             if (!e) return folly::makeUnexpected(BlobError::UNKNOWN_SHARD);
             if (ShardInfo::State::SEALED == e.value().state) return folly::makeUnexpected(BlobError::SEALED_SHARD);
+            if (blob.body.size() == 0) return folly::makeUnexpected(BlobError::INVALID_ARG);
             return _put_blob(e.value(), std::move(blob));
         });
 }

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -97,6 +97,8 @@ public:
                 auto b = _obj_inst->blob_manager()->put(shard_id, std::move(put_blob)).get();
                 if (!b && b.error() == BlobError::NOT_LEADER) {
                     LOGINFO("Failed to put blob due to not leader, sleep 1s and retry put", pg_id, shard_id);
+                    put_blob = homeobject::Blob{sisl::io_blob_safe(blob_size, alignment), user_key, 42ul};
+                    std::memcpy(put_blob.body.bytes(), clone.body.bytes(), clone.body.size());
                     std::this_thread::sleep_for(1s);
                     goto retry;
                 }


### PR DESCRIPTION
Put_blob takes `Blob&& blob` which will make the provided blob into an empty one.

In previous code we introduced retry logic for put_blob however didnt properly recreate the blob buffer which mistakenly create an empty blob with size=0.

As we only retry on not_leader and this error is not local-retryable, we dont have a case that need local retry now. It still make sense to take right value ref for blob.  Caller (now only the UT) should take responsibility to copy before call, if retry is intended.

Rejecting zero-length put will better help user to identify the error.