### PR TITLE
recover pg before repl dev is started

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.0.7"
+    version = "2.0.8"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -4,7 +4,7 @@
 namespace homeobject {
 void ReplicationStateMachine::on_commit(int64_t lsn, const sisl::blob& header, const sisl::blob& key,
                                         const homestore::MultiBlkId& pbas, cintrusive< homestore::repl_req_ctx >& ctx) {
-    LOGI("applying raft log commit with lsn:{}", lsn);
+    LOGD("applying raft log commit with lsn:{}", lsn);
     const ReplicationMessageHeader* msg_header = r_cast< const ReplicationMessageHeader* >(header.cbytes());
     switch (msg_header->msg_type) {
     case ReplicationMessageType::CREATE_PG_MSG: {
@@ -32,7 +32,7 @@ void ReplicationStateMachine::on_commit(int64_t lsn, const sisl::blob& header, c
 
 bool ReplicationStateMachine::on_pre_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
                                             cintrusive< homestore::repl_req_ctx >& ctx) {
-    LOGI("on_pre_commit with lsn:{}", lsn);
+    LOGD("on_pre_commit with lsn:{}", lsn);
     // For shard creation, since homestore repldev inside will write shard header to data service first before this
     // function is called. So there is nothing is needed to do and we can get the binding chunk_id with the newly shard
     // from the blkid in on_commit()


### PR DESCRIPTION
When the raft_repl_dev recovers in homestore, it replays the nuraft logs and calls on_commit for the lsn values greater than checkpoint lsn. PG recovery should be complete in Homeobject to commit the lsn. This PR moves the PG and shard recovery before raft_repl_dev is created while metablk recovery is happening. 