### PR TITLE
raft test framework for homeobject

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.5"
+    version = "2.1.6"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -50,7 +50,6 @@ add_subdirectory(tests)
 add_executable (homestore_test)
 target_sources(homestore_test PRIVATE
     $<TARGET_OBJECTS:homestore_tests>
-    $<TARGET_OBJECTS:test_fixture>
 )
 target_link_libraries(homestore_test PUBLIC
     homeobject_homestore

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -177,7 +177,8 @@ void HSHomeObject::init_homestore() {
             auto run_on_type = has_fast_dev ? homestore::HSDevType::Fast : homestore::HSDevType::Data;
             LOGD("Running with Single mode, all service on {}", run_on_type);
             HomeStore::instance()->format_and_start({
-	        // FIXME:  this is to work around the issue in HS that varsize allocator doesnt work with small chunk size.
+                // FIXME:  this is to work around the issue in HS that varsize allocator doesnt work with small chunk
+                // size.
                 {HS_SERVICE::META, hs_format_params{.dev_type = run_on_type, .size_pct = 5.0, .num_chunks = 1}},
                 {HS_SERVICE::LOG, hs_format_params{.dev_type = run_on_type, .size_pct = 10.0, .chunk_size = 32 * Mi}},
                 {HS_SERVICE::INDEX, hs_format_params{.dev_type = run_on_type, .size_pct = 5.0, .num_chunks = 1}},
@@ -280,6 +281,7 @@ void HSHomeObject::register_homestore_metablk_callback() {
 }
 
 HSHomeObject::~HSHomeObject() {
+    LOGI("HomeObject start destructing");
 #if 0
     if (ho_timer_thread_handle_.first) {
         iomanager.cancel_timer(ho_timer_thread_handle_, true);

--- a/src/lib/homestore_backend/hs_http_manager.cpp
+++ b/src/lib/homestore_backend/hs_http_manager.cpp
@@ -45,8 +45,8 @@ HttpManager::HttpManager(HSHomeObject& ho) : ho_(ho) {
         return;
     }
     try {
-         http_server->setup_routes(routes);
-    } catch (std::runtime_error const& e) { LOGERROR("setup routes failed, {}", e.what()) }
+        http_server->setup_routes(routes);
+    } catch (std::runtime_error const& e) { LOGINFO("setup routes failed, {}", e.what()); }
 }
 
 void HttpManager::get_obj_life(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response) {

--- a/src/lib/homestore_backend/hs_http_manager.cpp
+++ b/src/lib/homestore_backend/hs_http_manager.cpp
@@ -46,7 +46,7 @@ HttpManager::HttpManager(HSHomeObject& ho) : ho_(ho) {
     }
     try {
         http_server->setup_routes(routes);
-    } catch (std::runtime_error const& e) { LOGINFO("setup routes failed, {}", e.what()); }
+    } catch (std::runtime_error const& e) { LOGERROR("setup routes failed, {}", e.what()); }
 }
 
 void HttpManager::get_obj_life(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response) {

--- a/src/lib/homestore_backend/tests/CMakeLists.txt
+++ b/src/lib/homestore_backend/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND TEST_SOURCES
     hs_blob_tests.cpp
     hs_pg_tests.cpp
     homeobj_cp_tests.cpp
+    test_homestore_backend.cpp
     )
 
 add_library(homestore_tests OBJECT)

--- a/src/lib/homestore_backend/tests/bits_generator.hpp
+++ b/src/lib/homestore_backend/tests/bits_generator.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <cstdint>
 #include <random>
-#include <iostream>
+#include <limits>
 
 namespace homeobject {
 
@@ -29,14 +29,27 @@ public:
     static void gen_random_bits(size_t size, uint8_t* buf) {
         std::random_device rd;
         std::default_random_engine g(rd());
-        std::uniform_int_distribution< unsigned long long > dis(std::numeric_limits< std::uint8_t >::min(),
-                                                                std::numeric_limits< std::uint8_t >::max());
+        std::uniform_int_distribution< std::uint8_t > dis(std::numeric_limits< std::uint8_t >::min(),
+                                                          std::numeric_limits< std::uint8_t >::max());
         for (size_t i = 0; i < size; ++i) {
             buf[i] = dis(g);
         }
     }
 
     static void gen_random_bits(sisl::blob& b) { gen_random_bits(b.size(), b.bytes()); }
+
+    // this function guarantees that the generated bits will be identical for the identical input of blob_id
+    // and size.
+    static void gen_blob_bits(size_t size, uint8_t* buf, blob_id_t blob_id) {
+        std::mt19937_64 rng(blob_id);
+        std::uniform_int_distribution< std::uint8_t > dist(std::numeric_limits< std::uint8_t >::min(),
+                                                           std::numeric_limits< std::uint8_t >::max());
+
+        for (size_t i = 0; i < size;)
+            buf[i++] = dist(rng);
+    }
+
+    static void gen_blob_bits(sisl::blob& b, blob_id_t blob_id) { gen_blob_bits(b.size(), b.bytes(), blob_id); }
 };
 
 }; // namespace homeobject

--- a/src/lib/homestore_backend/tests/homeobj_cp_tests.cpp
+++ b/src/lib/homestore_backend/tests/homeobj_cp_tests.cpp
@@ -4,17 +4,13 @@ TEST_F(HomeObjectFixture, HSHomeObjectCPTestBasic) {
     // Step-1: create a PG and a shard
     std::vector< std::pair< pg_id_t, shard_id_t > > pg_shard_id_vec;
     create_pg(1 /* pg_id */);
-    auto shard = _obj_inst->shard_manager()->create_shard(1 /* pg_id */, 64 * Mi).get();
-    ASSERT_TRUE(!!shard);
-    pg_shard_id_vec.emplace_back(1 /* pg_id */, shard->id);
-    LOGINFO("pg {} shard {}", 1, shard->id);
-
-    using namespace homestore;
-    auto ho = dynamic_cast< HSHomeObject* >(_obj_inst.get());
+    auto shard_info = create_shard(1 /* pg_id */, 64 * Mi);
+    pg_shard_id_vec.emplace_back(1 /* pg_id */, shard_info.id);
+    LOGINFO("pg {} shard {}", 1, shard_info.id);
     {
         // Step-2: write some dirty pg information and add to dirt list;
-        auto lg = std::unique_lock(ho->_pg_lock);
-        for (auto& [_, pg] : ho->_pg_map) {
+        auto lg = std::unique_lock(_obj_inst->_pg_lock);
+        for (auto& [_, pg] : _obj_inst->_pg_map) {
             auto hs_pg = static_cast< HSHomeObject::HS_PG* >(pg.get());
             hs_pg->durable_entities_.blob_sequence_num = 54321; // fake some random blob seq number to make it dirty;
             hs_pg->is_dirty_.store(true);
@@ -26,20 +22,12 @@ TEST_F(HomeObjectFixture, HSHomeObjectCPTestBasic) {
         }
     }
 
-    // Step-3: trigger a cp;
-    trigger_cp(true /* wait */);
+    restart();
 
-    _obj_inst.reset();
-
-    // Step-4: re-create the homeobject and pg infos and shard infos will be recover automatically.
-    _obj_inst = homeobject::init_homeobject(std::weak_ptr< homeobject::HomeObjectApplication >(app));
-
-    ho = dynamic_cast< homeobject::HSHomeObject* >(_obj_inst.get());
-
-    EXPECT_TRUE(ho->_pg_map.size() == 1);
+    EXPECT_TRUE(_obj_inst->_pg_map.size() == 1);
     {
-        auto lg = std::shared_lock(ho->_pg_lock);
-        for (auto& [_, pg] : ho->_pg_map) {
+        auto lg = std::shared_lock(_obj_inst->_pg_lock);
+        for (auto& [_, pg] : _obj_inst->_pg_map) {
             auto hs_pg = static_cast< HSHomeObject::HS_PG* >(pg.get());
             EXPECT_EQ(hs_pg->durable_entities_.blob_sequence_num, 12345);
         }

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -12,8 +12,9 @@
 #define private public
 
 #include "lib/homestore_backend/hs_homeobject.hpp"
-#include "lib/tests/fixture_app.hpp"
 #include "bits_generator.hpp"
+#include "hs_repl_test_helper.hpp"
+
 using namespace std::chrono_literals;
 
 using homeobject::BlobError;
@@ -24,123 +25,238 @@ using homeobject::ShardError;
 using namespace homeobject;
 
 #define hex_bytes(buffer, len) fmt::format("{}", spdlog::to_hex((buffer), (buffer) + (len)))
+
+extern std::unique_ptr< test_common::HSReplTestHelper > g_helper;
+
 class HomeObjectFixture : public ::testing::Test {
 public:
-    std::shared_ptr< FixtureApp > app;
-    std::shared_ptr< homeobject::HomeObject > _obj_inst;
-    std::random_device rnd{};
-    std::default_random_engine rnd_engine{rnd()};
+    std::shared_ptr< homeobject::HSHomeObject > _obj_inst;
+
+    // Create blob size in range (1, 16kb) and user key in range (1, 1kb)
+    HomeObjectFixture() : rand_blob_size{1u, 16 * 1024}, rand_user_key_size{1u, 1024} {}
 
     void SetUp() override {
-        app = std::make_shared< FixtureApp >(true /* is_hybrid */);
-        _obj_inst = homeobject::init_homeobject(std::weak_ptr< homeobject::HomeObjectApplication >(app));
+        _obj_inst = std::dynamic_pointer_cast< HSHomeObject >(g_helper->build_new_homeobject());
+        g_helper->sync_for_test_start();
     }
 
-    void TearDown() override { app->clean(); }
-
-    void create_pg(pg_id_t pg_id) {
-        auto info = homeobject::PGInfo(pg_id);
-        auto peer1 = _obj_inst->our_uuid();
-        info.members.insert(homeobject::PGMember{peer1, "peer1", 1});
-
-        // TODO:: add the following back when we have 3-replica raft test framework
-        /*
-        auto peer2 = boost::uuids::random_generator()();
-        auto peer3 = boost::uuids::random_generator()();
-        info.members.insert(homeobject::PGMember{peer2, "peer2", 0});
-        info.members.insert(homeobject::PGMember{peer3, "peer3", 0});
-        */
-
-        auto p = _obj_inst->pg_manager()->create_pg(std::move(info)).get();
-        ASSERT_TRUE(!!p);
+    void TearDown() override {
+        g_helper->sync_for_cleanup_start();
+        _obj_inst.reset();
+        g_helper->delete_homeobject();
     }
 
-    static void trigger_cp(bool wait) {
-        auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(true /* force */);
-        auto on_complete = [&](auto success) {
-            EXPECT_EQ(success, true);
-            LOGINFO("CP Flush completed");
-        };
+    void restart() {
+        g_helper->sync_for_cleanup_start();
+        trigger_cp(true);
+        _obj_inst.reset();
+        _obj_inst = std::dynamic_pointer_cast< HSHomeObject >(g_helper->restart());
+        // wait for leader to be elected
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+    }
 
-        if (wait) {
-            on_complete(std::move(fut).get());
+    // schedule create_pg to replica_num
+    void create_pg(pg_id_t pg_id, uint32_t replica_num = 0) {
+        if (replica_num == g_helper->replica_num()) {
+            auto memebers = g_helper->members();
+            auto name = g_helper->name();
+            auto info = homeobject::PGInfo(pg_id);
+            for (const auto& member : memebers) {
+                if (replica_num == member.second) {
+                    // by default, leader is the first member
+                    info.members.insert(homeobject::PGMember{member.first, name + std::to_string(member.second), 1});
+                } else {
+                    info.members.insert(homeobject::PGMember{member.first, name + std::to_string(member.second), 0});
+                }
+            }
+            auto p = _obj_inst->pg_manager()->create_pg(std::move(info)).get();
+            ASSERT_TRUE(p);
+            LOGINFO("pg {} is created at leader", pg_id);
         } else {
-            std::move(fut).thenValue(on_complete);
+            // follower need to wait for pg creation to complete locally
+            while (!pg_exist(pg_id)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+            }
+            LOGINFO("pg {} is created at follower", pg_id);
         }
     }
 
-    using blob_map_t = std::map< std::tuple< pg_id_t, shard_id_t, blob_id_t >, homeobject::Blob >;
+    ShardInfo create_shard(pg_id_t pg_id, uint64_t size_bytes) {
+        g_helper->sync_for_uint64_id();
+        RELEASE_ASSERT(pg_exist(pg_id), "PG {} does not exist", pg_id);
 
-    void put_blob(blob_map_t& blob_map, std::vector< std::pair< pg_id_t, shard_id_t > > const& pg_shard_id_vec,
-                  uint64_t const num_blobs_per_shard, uint32_t const max_blob_size) {
-        std::uniform_int_distribution< uint32_t > rand_blob_size{1u, max_blob_size};
-        std::uniform_int_distribution< uint32_t > rand_user_key_size{1u, 1 * 1024};
+        // schedule create_shard only on leader
+        run_on_pg_leader(pg_id, [&]() {
+            auto s = _obj_inst->shard_manager()->create_shard(pg_id, size_bytes).get();
+            RELEASE_ASSERT(!!s, "failed to create shard");
+            auto ret = s.value();
+            g_helper->set_uint64_id(ret.id);
+        });
 
-        for (const auto& id : pg_shard_id_vec) {
-            int64_t pg_id = id.first, shard_id = id.second;
-            for (uint64_t k = 0; k < num_blobs_per_shard; k++) {
-                uint32_t alignment = 512;
-                // Create non 512 byte aligned address to create copy.
-                if (k % 2 == 0) alignment = 256;
+        // all the members need to wait for shard creation to complete locally
+        while (g_helper->get_uint64_id() == INVALID_UINT64_ID) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
 
-                std::string user_key;
-                user_key.resize(rand_user_key_size(rnd_engine));
-                BitsGenerator::gen_random_bits(user_key.size(), (uint8_t*)user_key.data());
-                auto blob_size = rand_blob_size(rnd_engine);
-                homeobject::Blob put_blob{sisl::io_blob_safe(blob_size, alignment), user_key, 42ul};
-                BitsGenerator::gen_random_bits(put_blob.body);
-                // Keep a copy of random payload to verify later.
-                homeobject::Blob clone{sisl::io_blob_safe(blob_size, alignment), user_key, 42ul};
-                std::memcpy(clone.body.bytes(), put_blob.body.bytes(), put_blob.body.size());
+        auto shard_id = g_helper->get_uint64_id();
 
-            retry:
-                auto b = _obj_inst->blob_manager()->put(shard_id, std::move(put_blob)).get();
-                if (!b && b.error().getCode() == BlobErrorCode::NOT_LEADER) {
-                    LOGINFO("Failed to put blob due to not leader, sleep 1s and retry put", pg_id, shard_id);
-                    put_blob = homeobject::Blob{sisl::io_blob_safe(blob_size, alignment), user_key, 42ul};
-                    std::memcpy(put_blob.body.bytes(), clone.body.bytes(), clone.body.size());
-                    std::this_thread::sleep_for(1s);
-                    goto retry;
+        while (!shard_exist(shard_id)) {
+            // for leader, shard creation is done locally and will nor reach here. but for follower, we need to wait for
+            // shard creation to complete locally
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+
+        auto r = _obj_inst->shard_manager()->get_shard(shard_id).get();
+        RELEASE_ASSERT(!!r, "failed to get shard {}", shard_id);
+        return r.value();
+    }
+
+    ShardInfo seal_shard(shard_id_t shard_id) {
+        // before seal shard, we need to wait all the memebers to complete shard state verification
+        g_helper->sync_for_verify_start();
+        auto r = _obj_inst->shard_manager()->get_shard(shard_id).get();
+        RELEASE_ASSERT(!!r, "failed to get shard {}", shard_id);
+        auto pg_id = r.value().placement_group;
+
+        run_on_pg_leader(pg_id, [&]() {
+            auto s = _obj_inst->shard_manager()->seal_shard(shard_id).get();
+            RELEASE_ASSERT(!!s, "failed to seal shard");
+        });
+
+        while (true) {
+            auto r = _obj_inst->shard_manager()->get_shard(shard_id).get();
+            RELEASE_ASSERT(!!r, "failed to get shard {}", shard_id);
+            auto shard_info = r.value();
+            if (shard_info.state == ShardInfo::State::SEALED) { return shard_info; }
+            // for leader, shard sealing is done locally and will nor reach here. but for follower, we need to wait for
+            // shard is sealed locally
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+    }
+
+    void put_blob(shard_id_t shard_id, Blob&& blob) {
+        g_helper->sync_for_uint64_id();
+        auto r = _obj_inst->shard_manager()->get_shard(shard_id).get();
+        RELEASE_ASSERT(!!r, "failed to get shard {}", shard_id);
+        auto pg_id = r.value().placement_group;
+
+        run_on_pg_leader(pg_id, [&]() {
+            auto b = _obj_inst->blob_manager()->put(shard_id, std::move(blob)).get();
+            RELEASE_ASSERT(!!b, "failed to pub blob");
+            g_helper->set_uint64_id(b.value());
+        });
+
+        while (g_helper->get_uint64_id() == INVALID_UINT64_ID) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+        auto blob_id = g_helper->get_uint64_id();
+
+        // make sure the blob is created locally
+        while (!blob_exist(shard_id, blob_id)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+    }
+
+    void put_blobs(std::map< pg_id_t, std::vector< shard_id_t > > const& pg_shard_id_vec,
+                   uint64_t const num_blobs_per_shard, std::map< pg_id_t, blob_id_t >& pg_blob_id) {
+        for (const auto& [pg_id, shard_vec] : pg_shard_id_vec) {
+            // the blob_id of a pg is a continuous number starting from 0 and increasing by 1
+            blob_id_t current_blob_id{pg_blob_id[pg_id]};
+
+            for (const auto& shard_id : shard_vec) {
+                for (uint64_t k = 0; k < num_blobs_per_shard; k++) {
+                    run_on_pg_leader(pg_id, [&]() {
+                        auto put_blob = build_blob(current_blob_id);
+
+                        LOGINFO("Put blob pg {} shard {} blob {} size {} data {}", pg_id, shard_id, current_blob_id,
+                                put_blob.body.size(),
+                                hex_bytes(put_blob.body.cbytes(), std::min(10u, put_blob.body.size())));
+
+                        auto b = _obj_inst->blob_manager()->put(shard_id, std::move(put_blob)).get();
+
+                        if (!b) {
+                            LOGERROR("Failed to put blob pg {} shard {} error={}", pg_id, shard_id, b.error());
+                            ASSERT_TRUE(false);
+                        }
+
+                        auto blob_id = b.value();
+                        ASSERT_EQ(blob_id, current_blob_id) << "the predicted blob id is not correct!";
+                    });
+
+                    current_blob_id++;
                 }
+            }
 
-                if (!b) {
-                    LOGERROR("Failed to put blob pg {} shard {} error={}", pg_id, shard_id, b.error());
-                    ASSERT_TRUE(false);
-                    continue;
+            // wait for the last blob to be created locally
+            auto shard_id = shard_vec.back();
+            pg_blob_id[pg_id] = current_blob_id;
+            auto last_blob_id = pg_blob_id[pg_id] - 1;
+            while (!blob_exist(shard_id, last_blob_id)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+            }
+            LOGINFO("shard {} blob {} is created locally, which means all the blob before {} are created", shard_id,
+                    last_blob_id, last_blob_id);
+        }
+    }
+
+    void del_all_blobs(std::map< pg_id_t, std::vector< shard_id_t > > const& pg_shard_id_vec,
+                       uint64_t const num_blobs_per_shard, std::map< pg_id_t, blob_id_t >& pg_blob_id) {
+        for (const auto& [pg_id, shard_vec] : pg_shard_id_vec) {
+            run_on_pg_leader(pg_id, [&]() {
+                blob_id_t current_blob_id{0};
+                for (; current_blob_id < pg_blob_id[pg_id];) {
+                    for (const auto& shard_id : shard_vec) {
+                        for (uint64_t k = 0; k < num_blobs_per_shard; k++) {
+                            auto g = _obj_inst->blob_manager()->del(shard_id, current_blob_id).get();
+                            ASSERT_TRUE(g);
+                            LOGINFO("delete blob shard {} blob {}", shard_id, current_blob_id);
+                            current_blob_id++;
+                        }
+                    }
                 }
-                auto blob_id = b.value();
-
-                LOGINFO("Put blob pg {} shard {} blob {} data {}", pg_id, shard_id, blob_id,
-                        hex_bytes(clone.body.cbytes(), std::min(10u, clone.body.size())));
-                blob_map.insert({{pg_id, shard_id, blob_id}, std::move(clone)});
+            });
+            auto shard_id = shard_vec.back();
+            auto blob_id = pg_blob_id[pg_id] - 1;
+            while (blob_exist(shard_id, blob_id)) {
+                LOGINFO("waiting for shard {} blob {} to be deleted locally", shard_id, blob_id);
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
             }
         }
     }
 
-    void verify_get_blob(blob_map_t const& blob_map, bool const use_random_offset = false) {
+    void verify_get_blob(std::map< pg_id_t, std::vector< shard_id_t > > const& pg_shard_id_vec,
+                         uint64_t const num_blobs_per_shard, bool const use_random_offset = false) {
         uint32_t off = 0, len = 0;
-        for (const auto& [id, blob] : blob_map) {
-            int64_t pg_id = std::get< 0 >(id), shard_id = std::get< 1 >(id), blob_id = std::get< 2 >(id);
-            len = blob.body.size();
-            if (use_random_offset) {
-                std::uniform_int_distribution< uint32_t > rand_off_gen{0u, blob.body.size() - 1u};
-                std::uniform_int_distribution< uint32_t > rand_len_gen{1u, blob.body.size()};
 
-                off = rand_off_gen(rnd_engine);
-                len = rand_len_gen(rnd_engine);
-                if ((off + len) >= blob.body.size()) { len = blob.body.size() - off; }
+        for (const auto& [pg_id, shard_vec] : pg_shard_id_vec) {
+            blob_id_t current_blob_id{0};
+            for (const auto& shard_id : shard_vec) {
+                for (uint64_t k = 0; k < num_blobs_per_shard; k++) {
+                    auto blob = build_blob(current_blob_id);
+                    len = blob.body.size();
+                    if (use_random_offset) {
+                        std::uniform_int_distribution< uint32_t > rand_off_gen{0u, len - 1u};
+                        std::uniform_int_distribution< uint32_t > rand_len_gen{1u, len};
+
+                        off = rand_off_gen(rnd_engine);
+                        len = rand_len_gen(rnd_engine);
+                        if ((off + len) >= blob.body.size()) { len = blob.body.size() - off; }
+                    }
+
+                    auto g = _obj_inst->blob_manager()->get(shard_id, current_blob_id, off, len).get();
+                    ASSERT_TRUE(!!g) << "get blob fail, shard_id " << shard_id << " blob_id " << current_blob_id
+                                     << " replica number " << g_helper->replica_num();
+                    auto result = std::move(g.value());
+                    LOGINFO("get blob pg {} shard {} blob {} off {} len {} data {}", pg_id, shard_id, current_blob_id,
+                            off, len, hex_bytes(result.body.cbytes(), std::min(len, 10u)));
+                    EXPECT_EQ(result.body.size(), len);
+                    EXPECT_EQ(std::memcmp(result.body.bytes(), blob.body.cbytes() + off, result.body.size()), 0);
+                    EXPECT_EQ(result.user_key.size(), blob.user_key.size());
+                    EXPECT_EQ(blob.user_key, result.user_key);
+                    EXPECT_EQ(blob.object_off, result.object_off);
+                    current_blob_id++;
+                }
             }
-
-            auto g = _obj_inst->blob_manager()->get(shard_id, blob_id, off, len).get();
-            ASSERT_TRUE(!!g);
-            auto result = std::move(g.value());
-            LOGINFO("After restart get blob pg {} shard {} blob {} off {} len {} data {}", pg_id, shard_id, blob_id,
-                    off, len, hex_bytes(result.body.cbytes(), std::min(len, 10u)));
-            EXPECT_EQ(result.body.size(), len);
-            EXPECT_EQ(std::memcmp(result.body.bytes(), blob.body.cbytes() + off, result.body.size()), 0);
-            EXPECT_EQ(result.user_key.size(), blob.user_key.size());
-            EXPECT_EQ(blob.user_key, result.user_key);
-            EXPECT_EQ(blob.object_off, result.object_off);
         }
     }
 
@@ -152,7 +268,8 @@ public:
         for (uint32_t i = 1; i <= num_pgs; ++i) {
             PGStats stats;
             _obj_inst->pg_manager()->get_stats(i, stats);
-            ASSERT_EQ(stats.num_active_objects, exp_active_blobs) << "Active objs stats not correct";
+            ASSERT_EQ(stats.num_active_objects, exp_active_blobs)
+                << "Active objs stats not correct " << g_helper->replica_num();
             ASSERT_EQ(stats.num_tombstone_objects, exp_tombstone_blobs) << "Deleted objs stats not correct";
         }
     }
@@ -185,10 +302,80 @@ public:
         }
     }
 
-    void restart() {
-        LOGINFO("Restarting homeobject.");
-        _obj_inst.reset();
-        _obj_inst = homeobject::init_homeobject(std::weak_ptr< homeobject::HomeObjectApplication >(app));
-        std::this_thread::sleep_for(std::chrono::seconds{1});
+    void verify_hs_shard(const ShardInfo& lhs, const ShardInfo& rhs) {
+        // operator == is already overloaded , so we need to compare each field
+        EXPECT_EQ(lhs.id, rhs.id);
+        EXPECT_EQ(lhs.placement_group, rhs.placement_group);
+        EXPECT_EQ(lhs.state, rhs.state);
+        EXPECT_EQ(lhs.lsn, rhs.lsn);
+        EXPECT_EQ(lhs.created_time, rhs.created_time);
+        EXPECT_EQ(lhs.last_modified_time, rhs.last_modified_time);
+        EXPECT_EQ(lhs.available_capacity_bytes, rhs.available_capacity_bytes);
+        EXPECT_EQ(lhs.total_capacity_bytes, rhs.total_capacity_bytes);
+        EXPECT_EQ(lhs.deleted_capacity_bytes, rhs.deleted_capacity_bytes);
+        EXPECT_EQ(lhs.current_leader, rhs.current_leader);
     }
+
+    void run_on_pg_leader(pg_id_t pg_id, auto&& lambda) {
+        PGStats pg_stats;
+        auto res = _obj_inst->pg_manager()->get_stats(pg_id, pg_stats);
+        RELEASE_ASSERT(res, "can not get pg {} stats", pg_id);
+        if (g_helper->my_replica_id() == pg_stats.leader_id) { lambda(); }
+        // TODO: add logic for check and retry of leader change if necessary
+    }
+
+private:
+    bool pg_exist(pg_id_t pg_id) {
+        std::vector< pg_id_t > pg_ids;
+        _obj_inst->pg_manager()->get_pg_ids(pg_ids);
+        return std::find(pg_ids.begin(), pg_ids.end(), pg_id) != pg_ids.end();
+    }
+
+    bool shard_exist(shard_id_t id) {
+        auto r = _obj_inst->shard_manager()->get_shard(id).get();
+        return !!r;
+    }
+
+    bool blob_exist(shard_id_t shard_id, blob_id_t blob_id) {
+        auto r = _obj_inst->blob_manager()->get(shard_id, blob_id).get();
+        return !!r;
+    }
+
+    void trigger_cp(bool wait) {
+        auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(true /* force */);
+        auto on_complete = [&](auto success) {
+            EXPECT_EQ(success, true);
+            LOGINFO("CP Flush completed");
+        };
+
+        if (wait) {
+            on_complete(std::move(fut).get());
+        } else {
+            std::move(fut).thenValue(on_complete);
+        }
+    }
+
+    homeobject::Blob build_blob(blob_id_t blob_id) {
+        uint32_t alignment = 512;
+        // Create non 512 byte aligned address to create copy.
+        if (blob_id % 2 == 0) alignment = 256;
+
+        // for different blob_id, we need to use different random engine, so that the rand_blob_size and
+        // rand_user_key_size and the content of user_key and blob will all be predictable
+        std::mt19937_64 predictable_engine(blob_id);
+
+        std::string user_key;
+        user_key.resize(rand_user_key_size(predictable_engine));
+        BitsGenerator::gen_blob_bits(user_key.size(), (uint8_t*)user_key.data(), blob_id);
+        auto blob_size = rand_blob_size(predictable_engine);
+        homeobject::Blob blob{sisl::io_blob_safe(blob_size, alignment), user_key, 42ul};
+        BitsGenerator::gen_blob_bits(blob.body, blob_id);
+        return blob;
+    }
+
+private:
+    std::random_device rnd{};
+    std::default_random_engine rnd_engine{rnd()};
+    std::uniform_int_distribution< uint32_t > rand_blob_size;
+    std::uniform_int_distribution< uint32_t > rand_user_key_size;
 };

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -51,10 +51,6 @@ TEST_F(HomeObjectFixture, BasicPutGetDelBlobWRestart) {
     // Verify the stats after restart
     verify_obj_count(num_pgs, num_blobs_per_shard, num_shards_per_pg, false /* deleted */);
 
-    // we need to sync here. if not then the leader deletion op will bring impact to follower`s verification if the
-    // follower is very slow. for example, the follower is still verifying blob abd obj_count , but the leader has
-    // already start deletion. so the follower will fail the verification.
-    g_helper->sync_for_test_start();
     //  Put blob after restart to test the persistance of blob sequence number
     put_blobs(pg_shard_id_vec, num_blobs_per_shard, pg_blob_id);
 
@@ -64,9 +60,6 @@ TEST_F(HomeObjectFixture, BasicPutGetDelBlobWRestart) {
     // Verify the stats after put blobs after restart
     verify_obj_count(num_pgs, num_blobs_per_shard * 2, num_shards_per_pg, false /* deleted */);
 
-    // we need to sync here, same reason as above.we can not use sync_for_test_start() twice without a new type of sync,
-    // so use sync_for_verify_start() here
-    g_helper->sync_for_verify_start();
     // Delete all blobs
     del_all_blobs(pg_shard_id_vec, num_blobs_per_shard, pg_blob_id);
 

--- a/src/lib/homestore_backend/tests/hs_pg_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_pg_tests.cpp
@@ -1,41 +1,34 @@
 #include "homeobj_fixture.hpp"
 
 TEST_F(HomeObjectFixture, PGStatsTest) {
-    // Create a pg, shard, put blob should succeed.
+    LOGINFO("HomeObject replica={} setup completed", g_helper->replica_num());
+    //  Create a pg, shard, put blob should succeed.
     pg_id_t pg_id{1};
     create_pg(pg_id);
-
-    auto s = _obj_inst->shard_manager()->create_shard(pg_id, 64 * Mi).get();
-    ASSERT_TRUE(!!s);
-    auto shard_info = s.value();
+    auto shard_info = create_shard(pg_id, 64 * Mi);
     auto shard_id = shard_info.id;
-    s = _obj_inst->shard_manager()->get_shard(shard_id).get();
+    auto s = _obj_inst->shard_manager()->get_shard(shard_id).get();
     ASSERT_TRUE(!!s);
-
-    LOGINFO("Got shard {}", shard_id);
+    LOGINFO("Got shard {}", shard_info.id);
     shard_info = s.value();
+
     EXPECT_EQ(shard_info.id, shard_id);
     EXPECT_EQ(shard_info.placement_group, pg_id);
     EXPECT_EQ(shard_info.state, ShardInfo::State::OPEN);
-    auto b = _obj_inst->blob_manager()->put(shard_id, Blob{sisl::io_blob_safe(512u, 512u), "test_blob", 0ul}).get();
-    ASSERT_TRUE(!!b);
-    LOGINFO("Put blob {}", b.value());
+    put_blob(shard_id, Blob{sisl::io_blob_safe(512u, 512u), "test_blob", 0ul});
 
-    // create a shard
-    s = _obj_inst->shard_manager()->seal_shard(shard_id).get();
-    ASSERT_TRUE(!!s);
-    shard_info = s.value();
+    // seal the shard
+    shard_info = seal_shard(shard_id);
     EXPECT_EQ(shard_info.id, shard_id);
     EXPECT_EQ(shard_info.placement_group, pg_id);
     EXPECT_EQ(shard_info.state, ShardInfo::State::SEALED);
     LOGINFO("Sealed shard {}", shard_id);
 
     // create a 2nd shard
-    auto s2 = _obj_inst->shard_manager()->create_shard(pg_id, 64 * Mi).get();
-    auto shard_info2 = s2.value();
+    auto shard_info2 = create_shard(pg_id, 64 * Mi);
     auto shard_id2 = shard_info2.id;
-    s2 = _obj_inst->shard_manager()->get_shard(shard_id2).get();
-    ASSERT_TRUE(!!s);
+    auto s2 = _obj_inst->shard_manager()->get_shard(shard_id2).get();
+    ASSERT_TRUE(!!s2);
     LOGINFO("Got shard {}", shard_id2);
 
     PGStats pg_stats;
@@ -46,8 +39,8 @@ TEST_F(HomeObjectFixture, PGStatsTest) {
     EXPECT_EQ(pg_stats.id, pg_id);
     EXPECT_EQ(pg_stats.total_shards, 2);
     EXPECT_EQ(pg_stats.open_shards, 1);
-    // TODO: EXPECT_EQ(pg_stats.num_members, 1) after having real 3-replica repl dev in test
-    EXPECT_EQ(pg_stats.num_members, 1);
+    // we have 3-replica test frame work now
+    EXPECT_EQ(pg_stats.num_members, g_helper->members().size());
 
     auto stats = _obj_inst->get_stats();
     LOGINFO("HomeObj stats: {}", stats.to_string());
@@ -55,7 +48,7 @@ TEST_F(HomeObjectFixture, PGStatsTest) {
 
 TEST_F(HomeObjectFixture, PGRecoveryTest) {
     // create 10 pg
-    for (pg_id_t i = 0; i < 10; i++) {
+    for (pg_id_t i = 1; i < 11; i++) {
         pg_id_t pg_id{i};
         create_pg(pg_id);
     }
@@ -71,14 +64,13 @@ TEST_F(HomeObjectFixture, PGRecoveryTest) {
     // restart
     restart();
 
-    ho = dynamic_cast< HSHomeObject* >(_obj_inst.get());
     // verify uuid
-    EXPECT_EQ(id, ho->our_uuid());
+    EXPECT_EQ(id, _obj_inst->our_uuid());
 
     // verify pg map
-    EXPECT_EQ(10, ho->_pg_map.size());
+    EXPECT_EQ(10, _obj_inst->_pg_map.size());
 
-    for (auto const& [id, pg] : ho->_pg_map) {
+    for (auto const& [id, pg] : _obj_inst->_pg_map) {
         EXPECT_TRUE(pg_map.contains(id));
         auto reserved_pg = dynamic_cast< HSHomeObject::HS_PG* >(pg_map[id].get());
         auto recovered_pg = dynamic_cast< HSHomeObject::HS_PG* >(pg.get());

--- a/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
+++ b/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
@@ -46,49 +46,20 @@ using namespace homeobject;
 
 namespace test_common {
 
-ENUM(repl_test_phase_t, uint32_t, REGISTER, TEST_RUN, VALIDATE, CLEANUP);
-
 class HSReplTestHelper {
 protected:
     struct IPCData {
-        bip::interprocess_mutex mtx_;
-        bip::interprocess_condition cv_;
-        bip::interprocess_mutex exec_mtx_;
-
-        repl_test_phase_t phase_{repl_test_phase_t::REGISTER};
-        uint32_t test_start_count_{0};
-        uint32_t verify_start_count_{0};
-        uint32_t cleanup_start_count_{0};
-
-        // the following variables are used to sync for shard and blob
-        uint64_t uint64_id_{0};
-        uint8_t homeobject_replica_count_{0};
-
-        // TODO:: now, we can not call the same syc type twice continuously, this will make the second sync ineffective.
-        // this will bring a little complexity to the UT writter to make sure the sync type is different between
-        // continuous syncs. will use another PR to remove this limitation and make the sync more flexible.
-
-        void sync_for_test_start(uint32_t num_members = 0) {
-            sync_for(test_start_count_, repl_test_phase_t::TEST_RUN, num_members);
-        }
-        void sync_for_verify_start(uint32_t num_members = 0) {
-            sync_for(verify_start_count_, repl_test_phase_t::VALIDATE, num_members);
-        }
-        void sync_for_cleanup_start(uint32_t num_members = 0) {
-            sync_for(cleanup_start_count_, repl_test_phase_t::CLEANUP, num_members);
-        }
-
-        // this is used for sync blob_id or shard_id among different replicas
-        void sync_for_uint64_id(uint32_t max_count = 0) {
-            if (max_count == 0) { max_count = SISL_OPTIONS["replicas"].as< uint32_t >(); }
+        void sync(uint64_t sync_point, uint32_t max_count = 0) {
+            if (max_count == 0) { max_count = SISL_OPTIONS["replicas"].as< uint8_t >(); }
             std::unique_lock< bip::interprocess_mutex > lg(mtx_);
             ++homeobject_replica_count_;
             if (homeobject_replica_count_ == max_count) {
-                uint64_id_ = INVALID_UINT64_ID;
+                sync_point_num_ = sync_point;
                 homeobject_replica_count_ = 0;
+                uint64_id_ = INVALID_UINT64_ID;
                 cv_.notify_all();
             } else {
-                cv_.wait(lg, [this]() { return uint64_id_ == INVALID_UINT64_ID; });
+                cv_.wait(lg, [this, sync_point]() { return sync_point_num_ == sync_point; });
             }
         }
 
@@ -103,19 +74,15 @@ protected:
         }
 
     private:
-        void sync_for(uint32_t& count, repl_test_phase_t new_phase, uint32_t max_count = 0) {
-            if (max_count == 0) { max_count = SISL_OPTIONS["replicas"].as< uint32_t >(); }
-            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
-            ++count;
-            if (count == max_count) {
-                phase_ = new_phase;
-                cv_.notify_all();
-            } else {
-                cv_.wait(lg, [this, new_phase]() { return (phase_ == new_phase); });
-            }
+        bip::interprocess_mutex mtx_;
+        bip::interprocess_condition cv_;
+        uint8_t homeobject_replica_count_{0};
 
-            count = 0;
-        }
+        // the following variables are used to share shard_id and blob_id among different replicas
+        uint64_t uint64_id_{0};
+
+        // the nth synchronization point, that is how many times different replicas have synced
+        uint64_t sync_point_num_{UINT64_MAX};
     };
 
 public:
@@ -265,7 +232,7 @@ public:
         return homeobj_;
     }
 
-    uint16_t replica_num() const { return replica_num_; }
+    uint8_t replica_num() const { return replica_num_; }
 
     peer_id_t my_replica_id() const { return my_replica_id_; }
 
@@ -288,11 +255,7 @@ public:
 
     void teardown() { sisl::GrpcAsyncClientWorker::shutdown_all(); }
 
-    void sync_for_test_start(uint32_t num_members = 0) { ipc_data_->sync_for_test_start(num_members); }
-    void sync_for_verify_start(uint32_t num_members = 0) { ipc_data_->sync_for_verify_start(num_members); }
-    void sync_for_cleanup_start(uint32_t num_members = 0) { ipc_data_->sync_for_cleanup_start(num_members); }
-
-    void sync_for_uint64_id(uint32_t num_members = 0) { ipc_data_->sync_for_uint64_id(num_members); }
+    void sync(uint32_t num_members = 0) { ipc_data_->sync(sync_point_num++, num_members); }
     void set_uint64_id(uint64_t uint64_id) { ipc_data_->set_uint64_id(uint64_id); }
     uint64_t get_uint64_id() { return ipc_data_->get_uint64_id(); }
 
@@ -365,7 +328,8 @@ private:
     }
 
 private:
-    uint16_t replica_num_;
+    uint8_t replica_num_;
+    uint64_t sync_point_num{0};
     std::string name_;
     std::vector< std::string > args_;
     char** argv_;

--- a/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
+++ b/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
@@ -1,0 +1,387 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+/*
+ * Homeobject Replication testing binaries shared common definitions, apis and data structures
+ */
+
+#pragma once
+#include <mutex>
+#include <condition_variable>
+#include <map>
+#include <set>
+#include <boost/process.hpp>
+#include <boost/asio.hpp>
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <boost/interprocess/sync/interprocess_mutex.hpp>
+#include <boost/interprocess/sync/interprocess_condition.hpp>
+#include <boost/uuid/string_generator.hpp>
+#include <boost/uuid/nil_generator.hpp>
+
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+#include <sisl/settings/settings.hpp>
+#include <sisl/grpc/rpc_client.hpp>
+
+#include <folly/init/Init.h>
+
+#include "homeobject/common.hpp"
+
+namespace bip = boost::interprocess;
+using namespace homeobject;
+
+#define INVALID_UINT64_ID UINT64_MAX
+
+namespace test_common {
+
+ENUM(repl_test_phase_t, uint32_t, REGISTER, TEST_RUN, VALIDATE, CLEANUP);
+
+class HSReplTestHelper {
+protected:
+    struct IPCData {
+        bip::interprocess_mutex mtx_;
+        bip::interprocess_condition cv_;
+        bip::interprocess_mutex exec_mtx_;
+
+        repl_test_phase_t phase_{repl_test_phase_t::REGISTER};
+        uint32_t test_start_count_{0};
+        uint32_t verify_start_count_{0};
+        uint32_t cleanup_start_count_{0};
+
+        // the following variables are used to sync for shard and blob
+        uint64_t uint64_id_{0};
+        uint8_t homeobject_replica_count_{0};
+
+        // TODO:: now, we can not call the same syc type twice continuously, this will make the second sync ineffective.
+        // this will bring a little complexity to the UT writter to make sure the sync type is different between
+        // continuous syncs. will use another PR to remove this limitation and make the sync more flexible.
+
+        void sync_for_test_start(uint32_t num_members = 0) {
+            sync_for(test_start_count_, repl_test_phase_t::TEST_RUN, num_members);
+        }
+        void sync_for_verify_start(uint32_t num_members = 0) {
+            sync_for(verify_start_count_, repl_test_phase_t::VALIDATE, num_members);
+        }
+        void sync_for_cleanup_start(uint32_t num_members = 0) {
+            sync_for(cleanup_start_count_, repl_test_phase_t::CLEANUP, num_members);
+        }
+
+        // this is used for sync blob_id or shard_id among different replicas
+        void sync_for_uint64_id(uint32_t max_count = 0) {
+            if (max_count == 0) { max_count = SISL_OPTIONS["replicas"].as< uint32_t >(); }
+            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
+            ++homeobject_replica_count_;
+            if (homeobject_replica_count_ == max_count) {
+                uint64_id_ = INVALID_UINT64_ID;
+                homeobject_replica_count_ = 0;
+                cv_.notify_all();
+            } else {
+                cv_.wait(lg, [this]() { return uint64_id_ == INVALID_UINT64_ID; });
+            }
+        }
+
+        void set_uint64_id(uint64_t input_uint64_id) {
+            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
+            uint64_id_ = input_uint64_id;
+        }
+
+        uint64_t get_uint64_id() {
+            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
+            return uint64_id_;
+        }
+
+    private:
+        void sync_for(uint32_t& count, repl_test_phase_t new_phase, uint32_t max_count = 0) {
+            if (max_count == 0) { max_count = SISL_OPTIONS["replicas"].as< uint32_t >(); }
+            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
+            ++count;
+            if (count == max_count) {
+                phase_ = new_phase;
+                cv_.notify_all();
+            } else {
+                cv_.wait(lg, [this, new_phase]() { return (phase_ == new_phase); });
+            }
+
+            count = 0;
+        }
+    };
+
+public:
+    class TestReplApplication : public homeobject::HomeObjectApplication {
+    private:
+        HSReplTestHelper& helper_;
+
+    public:
+        TestReplApplication(HSReplTestHelper& h) : helper_{h} {}
+        virtual ~TestReplApplication() = default;
+
+        // implement all the virtual functions in HomeObjectApplication
+        bool spdk_mode() const override { return SISL_OPTIONS["spdk"].as< bool >(); }
+        uint32_t threads() const override { return SISL_OPTIONS["num_threads"].as< uint32_t >(); }
+
+        std::list< device_info_t > devices() const override {
+            auto const use_file = SISL_OPTIONS["use_file"].as< bool >();
+            std::list< device_info_t > devs;
+            if (SISL_OPTIONS.count("device_list") && !use_file) {
+                for (const auto& dev : helper_.dev_list_)
+                    devs.emplace_back(dev, DevType::HDD);
+            } else {
+                for (const auto& dev : helper_.generated_devs)
+                    devs.emplace_back(dev, DevType::HDD);
+            }
+            return devs;
+        }
+
+        peer_id_t discover_svcid(std::optional< peer_id_t > const& p) const override {
+            if (p.has_value()) RELEASE_ASSERT_EQ(p.value(), helper_.my_replica_id_, "input svcid not matching");
+            return helper_.my_replica_id_;
+        }
+
+        std::string lookup_peer(peer_id_t const& pid) const override {
+            uint16_t port;
+            if (auto it = helper_.members_.find(pid); it != helper_.members_.end()) {
+                port = SISL_OPTIONS["base_port"].as< uint16_t >() + it->second;
+            } else {
+                RELEASE_ASSERT(false, "Gotten lookup_peer call for a non member");
+            }
+
+            return std::string("127.0.0.1:") + std::to_string(port);
+        }
+    };
+
+public:
+    friend class TestReplApplication;
+
+    HSReplTestHelper(std::string const& name, std::vector< std::string > const& args, char** argv) :
+            name_{name}, args_{args}, argv_{argv} {}
+
+    void setup(uint32_t num_replicas) {
+        num_replicas_ = num_replicas;
+        replica_num_ = SISL_OPTIONS["replica_num"].as< uint16_t >();
+
+        sisl::logging::SetLogger(name_ + std::string("_replica_") + std::to_string(replica_num_));
+        sisl::logging::SetLogPattern("[%D %T%z] [%^%L%$] [%n] [%t] %v");
+
+        boost::uuids::string_generator gen;
+        for (uint32_t i{0}; i < num_replicas; ++i) {
+            auto replica_id = gen(fmt::format("{:04}", i) + std::string("0123456789abcdef0123456789ab"));
+            if (i == replica_num_) { my_replica_id_ = replica_id; }
+            members_.insert(std::pair(replica_id, i));
+        }
+
+        // example:
+        // --num_replicas 3 --replica_dev_list replica_0_dev_1, replica_0_dev_2, replica_0_dev_3, replica_1_dev_1,
+        // replica_1_dev_2, replica_1_dev_3, replica_2_dev_1, replica_2_dev_2, replica_2_dev_3    // every replica 3
+        // devs;
+        // --num_replicas 3 --replica_dev_list replica_0_dev_1, replica_1_dev_1, replica_2_dev_1  // <<< every
+        // replica has 1 dev;
+        std::vector< std::string > dev_list_all;
+        std::vector< std::vector< std::string > > rdev_list(num_replicas);
+        if (SISL_OPTIONS.count("replica_dev_list")) {
+            dev_list_all = SISL_OPTIONS["replica_dev_list"].as< std::vector< std::string > >();
+            RELEASE_ASSERT(dev_list_all.size() % num_replicas == 0,
+                           "Number of replica devices should be times of number replicas");
+            LOGINFO("Device list from input={}", fmt::join(dev_list_all, ","));
+            uint32_t num_devs_per_replica = dev_list_all.size() / num_replicas;
+            for (uint32_t i{0}; i < num_replicas; ++i) {
+                for (uint32_t j{0}; j < num_devs_per_replica; ++j) {
+                    rdev_list[i].push_back(dev_list_all[i * num_devs_per_replica + j]);
+                }
+            }
+            for (auto const& dev : rdev_list[replica_num_]) {
+                dev_list_.emplace_back(dev);
+            }
+        }
+        name_ += std::to_string(replica_num_);
+
+        // prepare_devices();
+
+        if (replica_num_ == 0) {
+            // Erase previous shmem and create a new shmem with IPCData structure
+            bip::shared_memory_object::remove("HO_repl_test_shmem");
+
+            // kill the previous processes using the port
+            for (uint32_t i = 0; i < num_replicas; ++i)
+                check_and_kill(SISL_OPTIONS["base_port"].as< uint16_t >() + i);
+
+            shm_ =
+                std::make_unique< bip::shared_memory_object >(bip::create_only, "HO_repl_test_shmem", bip::read_write);
+            shm_->truncate(sizeof(IPCData));
+            region_ = std::make_unique< bip::mapped_region >(*shm_, bip::read_write);
+            ipc_data_ = new (region_->get_address()) IPCData;
+
+            for (uint32_t i{1}; i < num_replicas; ++i) {
+                LOGINFO("Spawning Homeobject replica={} instance", i);
+
+                std::string cmd_line;
+                fmt::format_to(std::back_inserter(cmd_line), "{} --replica_num {}", args_[0], i);
+                for (int j{1}; j < (int)args_.size(); ++j) {
+                    fmt::format_to(std::back_inserter(cmd_line), " {}", args_[j]);
+                }
+                boost::process::child c(boost::process::cmd = cmd_line, proc_grp_);
+                c.detach();
+            }
+        } else {
+            shm_ = std::make_unique< bip::shared_memory_object >(bip::open_only, "HO_repl_test_shmem", bip::read_write);
+            region_ = std::make_unique< bip::mapped_region >(*shm_, bip::read_write);
+            ipc_data_ = static_cast< IPCData* >(region_->get_address());
+        }
+
+        int tmp_argc = 1;
+        folly_ = std::make_unique< folly::Init >(&tmp_argc, &argv_, true);
+
+        LOGINFO("Starting HomeObject replica={}", replica_num_);
+        app = std::make_shared< TestReplApplication >(*this);
+    }
+
+    std::shared_ptr< homeobject::HomeObject > build_new_homeobject() {
+        prepare_devices();
+        homeobj_ = init_homeobject(std::weak_ptr< TestReplApplication >(app));
+        return homeobj_;
+    }
+
+    void delete_homeobject() {
+        LOGINFO("Clearing Homeobject replica={}", replica_num_);
+        homeobj_.reset();
+        remove_test_files();
+    }
+
+    std::shared_ptr< homeobject::HomeObject > restart(uint32_t shutdown_delay_secs = 5u) {
+        LOGINFO("Restarting homeobject replica={}", replica_num_);
+        homeobj_.reset();
+        homeobj_ = init_homeobject(std::weak_ptr< TestReplApplication >(app));
+        return homeobj_;
+    }
+
+    uint16_t replica_num() const { return replica_num_; }
+
+    peer_id_t my_replica_id() const { return my_replica_id_; }
+
+    peer_id_t replica_id(uint16_t member_id) const {
+        auto it = std::find_if(members_.begin(), members_.end(),
+                               [member_id](auto const& p) { return p.second == member_id; });
+        if (it != members_.end()) { return it->first; }
+        return boost::uuids::nil_uuid();
+    }
+
+    uint16_t member_id(peer_id_t replica_id) const {
+        auto it = members_.find(replica_id);
+        if (it != members_.end()) { return it->second; }
+        return members_.size();
+    }
+
+    std::map< peer_id_t, uint32_t > const& members() const { return members_; }
+
+    std::string name() const { return name_; }
+
+    void teardown() { sisl::GrpcAsyncClientWorker::shutdown_all(); }
+
+    void sync_for_test_start(uint32_t num_members = 0) { ipc_data_->sync_for_test_start(num_members); }
+    void sync_for_verify_start(uint32_t num_members = 0) { ipc_data_->sync_for_verify_start(num_members); }
+    void sync_for_cleanup_start(uint32_t num_members = 0) { ipc_data_->sync_for_cleanup_start(num_members); }
+
+    void sync_for_uint64_id(uint32_t num_members = 0) { ipc_data_->sync_for_uint64_id(num_members); }
+    void set_uint64_id(uint64_t uint64_id) { ipc_data_->set_uint64_id(uint64_id); }
+    uint64_t get_uint64_id() { return ipc_data_->get_uint64_id(); }
+
+    void check_and_kill(int port) {
+        std::string command = "lsof -t -i:" + std::to_string(port);
+        if (::system(command.c_str())) {
+            std::cout << "Port " << port << " is not in use." << std::endl;
+        } else {
+            std::cout << "Port " << port << " is in use. Trying to kill the process..." << std::endl;
+            command += " | xargs kill -9";
+            int result = ::system(command.c_str());
+            if (result == 0) {
+                std::cout << "Killed the process using port " << port << std::endl;
+            } else {
+                std::cout << "Failed to kill the process." << std::endl;
+            }
+        }
+    }
+
+private:
+    void prepare_devices(bool init_device = true) {
+        auto const use_file = SISL_OPTIONS["use_file"].as< bool >();
+        auto const ndevices = SISL_OPTIONS["num_devs"].as< uint32_t >();
+        auto const dev_size = SISL_OPTIONS["dev_size_mb"].as< uint64_t >() * 1024 * 1024;
+        if (use_file && !dev_list_.empty()) LOGWARN("Ignoring device_list as use_file is set to true");
+        if (!use_file && !dev_list_.empty()) {
+            init_raw_devices(dev_list_);
+        } else {
+            for (uint32_t i{0}; i < ndevices; ++i) {
+                generated_devs.emplace_back(std::string{"/tmp/" + name_ + "_" + std::to_string(i + 1)});
+            }
+            if (init_device) {
+                LOGINFO("creating {} device files with each of size {} ", ndevices, homestore::in_bytes(dev_size));
+                init_files(generated_devs, dev_size);
+            }
+        }
+    }
+
+    void remove_test_files() {
+        for (auto const& dev : generated_devs) {
+            if (std::filesystem::exists(dev)) std::filesystem::remove(dev);
+        }
+        generated_devs.clear();
+    }
+
+    void init_raw_devices(const std::vector< std::string >& devs) {
+        // TODO: do not use 4096 and 0 directly, instead use the constants from homestore::hs_super_blk
+        auto const zero_size = 4096 /*homestore::hs_super_blk::first_block_size()*/ * 1024;
+        std::vector< int > zeros(zero_size, 0);
+        for (auto const& path : devs) {
+            if (!std::filesystem::exists(path)) { RELEASE_ASSERT(false, "Device {} does not exist", path); }
+
+            auto fd = ::open(path.c_str(), O_RDWR, 0640);
+            RELEASE_ASSERT(fd != -1, "Failed to open device");
+
+            auto const write_sz =
+                pwrite(fd, zeros.data(), zero_size /* size */, 0 /*homestore::hs_super_blk::first_block_offset())*/);
+            RELEASE_ASSERT(write_sz == zero_size, "Failed to write to device");
+            LOGINFO("Successfully zeroed the 1st {} bytes of device {}", zero_size, path);
+            ::close(fd);
+        }
+    }
+
+    void init_files(const std::vector< std::string >& file_paths, uint64_t dev_size) {
+        for (const auto& fpath : file_paths) {
+            if (std::filesystem::exists(fpath)) std::filesystem::remove(fpath);
+            std::ofstream ofs{fpath, std::ios::binary | std::ios::out | std::ios::trunc};
+            std::filesystem::resize_file(fpath, dev_size);
+        }
+    }
+
+private:
+    uint16_t replica_num_;
+    std::string name_;
+    std::vector< std::string > args_;
+    char** argv_;
+    uint32_t num_replicas_;
+    std::vector< std::string > generated_devs;
+    std::vector< std::string > dev_list_;
+    std::shared_ptr< homeobject::HomeObject > homeobj_;
+
+    boost::process::group proc_grp_;
+    std::unique_ptr< bip::shared_memory_object > shm_;
+    std::unique_ptr< bip::mapped_region > region_;
+    std::unique_ptr< folly::Init > folly_;
+    std::map< peer_id_t, uint32_t > members_;
+    peer_id_t my_replica_id_;
+    IPCData* ipc_data_;
+
+    std::shared_ptr< TestReplApplication > app;
+};
+} // namespace test_common

--- a/src/lib/homestore_backend/tests/test_homestore_backend.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend.cpp
@@ -26,8 +26,7 @@ SISL_OPTION_GROUP(
      "true or false"),
     (init_device, "", "init_device", "init real device", ::cxxopts::value< bool >()->default_value("false"),
      "true or false"),
-    (replicas, "", "replicas", "Total number of replicas", ::cxxopts::value< uint32_t >()->default_value("3"),
-     "number"),
+    (replicas, "", "replicas", "Total number of replicas", ::cxxopts::value< uint8_t >()->default_value("3"), "number"),
     (spare_replicas, "", "spare_replicas", "Additional number of spare replicas not part of repldev",
      ::cxxopts::value< uint32_t >()->default_value("1"), "number"),
     (base_port, "", "base_port", "Port number of first replica", ::cxxopts::value< uint16_t >()->default_value("4000"),
@@ -60,7 +59,7 @@ int main(int argc, char* argv[]) {
     SISL_OPTIONS_LOAD(parsed_argc, argv, test_options);
 
     g_helper = std::make_unique< test_common::HSReplTestHelper >("test_homeobject", args, orig_argv);
-    g_helper->setup(SISL_OPTIONS["replicas"].as< uint32_t >());
+    g_helper->setup(SISL_OPTIONS["replicas"].as< uint8_t >());
     auto ret = RUN_ALL_TESTS();
     g_helper->teardown();
     return ret;

--- a/src/lib/homestore_backend/tests/test_homestore_backend.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend.cpp
@@ -1,0 +1,67 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+#include "homeobj_fixture.hpp"
+
+SISL_OPTION_GROUP(
+    test_homeobject_repl_common,
+    (spdk, "", "spdk", "spdk", ::cxxopts::value< bool >()->default_value("false"), "true or false"),
+    (dev_size_mb, "", "dev_size_mb", "size of each device in MB", ::cxxopts::value< uint64_t >()->default_value("2048"),
+     "number"),
+    (num_threads, "", "num_threads", "number of threads", ::cxxopts::value< uint32_t >()->default_value("2"), "number"),
+    (num_devs, "", "num_devs", "number of devices to create", ::cxxopts::value< uint32_t >()->default_value("3"),
+     "number"),
+    (use_file, "", "use_file", "use file instead of real drive", ::cxxopts::value< bool >()->default_value("false"),
+     "true or false"),
+    (init_device, "", "init_device", "init real device", ::cxxopts::value< bool >()->default_value("false"),
+     "true or false"),
+    (replicas, "", "replicas", "Total number of replicas", ::cxxopts::value< uint32_t >()->default_value("3"),
+     "number"),
+    (spare_replicas, "", "spare_replicas", "Additional number of spare replicas not part of repldev",
+     ::cxxopts::value< uint32_t >()->default_value("1"), "number"),
+    (base_port, "", "base_port", "Port number of first replica", ::cxxopts::value< uint16_t >()->default_value("4000"),
+     "number"),
+    (replica_num, "", "replica_num", "Internal replica num (used to lauch multi process) - don't override",
+     ::cxxopts::value< uint16_t >()->default_value("0"), "number"),
+    (replica_dev_list, "", "replica_dev_list", "Device list for all replicas",
+     ::cxxopts::value< std::vector< std::string > >(), "path [...]"),
+    (num_io, "", "num_io", "number of IO operations", ::cxxopts::value< uint64_t >()->default_value("300"), "number"),
+    (qdepth, "", "qdepth", "Max outstanding operations", ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
+    (num_pgs, "", "num_pgs", "number of pgs", ::cxxopts::value< uint64_t >()->default_value("2"), "number"),
+    (num_shards, "", "num_shards", "number of shards", ::cxxopts::value< uint64_t >()->default_value("4"), "number"),
+    (num_blobs, "", "num_blobs", "number of blobs", ::cxxopts::value< uint64_t >()->default_value("20"), "number"));
+
+// SISL_LOGGING_INIT(HOMEOBJECT_LOG_MODS)
+SISL_LOGGING_INIT(homeobject)
+#define test_options logging, config, homeobject, test_homeobject_repl_common
+SISL_OPTIONS_ENABLE(test_options)
+
+std::unique_ptr< test_common::HSReplTestHelper > g_helper;
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    char** orig_argv = argv;
+    std::vector< std::string > args;
+    for (int i = 0; i < argc; ++i) {
+        args.emplace_back(argv[i]);
+    }
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, test_options);
+
+    g_helper = std::make_unique< test_common::HSReplTestHelper >("test_homeobject", args, orig_argv);
+    g_helper->setup(SISL_OPTIONS["replicas"].as< uint32_t >());
+    auto ret = RUN_ALL_TESTS();
+    g_helper->teardown();
+    return ret;
+}


### PR DESCRIPTION
1 add a raft test framework for homeobject , which will enable 3-replica raft-based test.
2 move all the current UT from single replica to 3 replicas raft-based
3 find and fix a blob sequence number bug after involving the new test framework. 