### PR TITLE
Shard Identical Layout

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.8"
+    version = "2.1.9"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -42,6 +42,7 @@ struct PGInfo {
     mutable MemberSet members;
     peer_id_t replica_set_uuid;
     uint64_t size;
+    uint64_t chunk_size;
 
     auto operator<=>(PGInfo const& rhs) const { return id <=> rhs.id; }
     auto operator==(PGInfo const& rhs) const { return id == rhs.id; }

--- a/src/include/homeobject/shard_manager.hpp
+++ b/src/include/homeobject/shard_manager.hpp
@@ -10,7 +10,7 @@
 namespace homeobject {
 
 ENUM(ShardError, uint16_t, UNKNOWN = 1, TIMEOUT, INVALID_ARG, NOT_LEADER, UNSUPPORTED_OP, UNKNOWN_PG, UNKNOWN_SHARD,
-     PG_NOT_READY, CRC_MISMATCH);
+     PG_NOT_READY, CRC_MISMATCH, NO_SPACE_LEFT);
 
 struct ShardInfo {
     enum class State : uint8_t {

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -6,6 +6,7 @@
 #include <homestore/vchunk.h>
 #include <homestore/homestore_decl.hpp>
 #include <homestore/blk.h>
+#include <sisl/utility/enum.hpp>
 
 #include <queue>
 #include <vector>
@@ -15,6 +16,8 @@
 
 namespace homeobject {
 
+ENUM(ChunkState, uint8_t, AVAILABLE = 0, INUSE);
+
 using csharedChunk = homestore::cshared< homestore::Chunk >;
 
 class HeapChunkSelector : public homestore::ChunkSelector {
@@ -23,27 +26,43 @@ public:
     ~HeapChunkSelector() = default;
 
     using VChunk = homestore::VChunk;
-    class VChunkComparator {
-    public:
-        bool operator()(VChunk& lhs, VChunk& rhs) { return lhs.available_blks() < rhs.available_blks(); }
-    };
-
-    class VChunkDefragComparator {
-    public:
-        bool operator()(VChunk& lhs, VChunk& rhs) { return lhs.get_defrag_nblks() < rhs.get_defrag_nblks(); }
-    };
-
-    using VChunkHeap = std::priority_queue< VChunk, std::vector< VChunk >, VChunkComparator >;
-    using VChunkDefragHeap = std::priority_queue< VChunk, std::vector< VChunk >, VChunkDefragComparator >;
-    using ChunkIdMap = std::unordered_map < homestore::chunk_num_t, homestore::chunk_num_t >; // used for real chunk id -> virtual chunk id map
     using chunk_num_t = homestore::chunk_num_t;
+
+    class ExtendedVChunk : public VChunk {
+    public:
+        ExtendedVChunk(csharedChunk const& chunk) :
+                VChunk(chunk), m_state(ChunkState::AVAILABLE), m_pg_id(), m_v_chunk_id() {}
+        ~ExtendedVChunk() = default;
+        ChunkState m_state;
+        std::optional< pg_id_t > m_pg_id;
+        std::optional< chunk_num_t > m_v_chunk_id;
+        bool available() const { return m_state == ChunkState::AVAILABLE; }
+    };
+
+    class ExtendedVChunkComparator {
+    public:
+        bool operator()(std::shared_ptr< ExtendedVChunk >& lhs, std::shared_ptr< ExtendedVChunk >& rhs) {
+            return lhs->available_blks() < rhs->available_blks();
+        }
+    };
+    using ExtendedVChunkHeap =
+        std::priority_queue< std::shared_ptr< ExtendedVChunk >, std::vector< std::shared_ptr< ExtendedVChunk > >,
+                             ExtendedVChunkComparator >;
 
     struct ChunkHeap {
         std::mutex mtx;
-        VChunkHeap m_heap;
+        ExtendedVChunkHeap m_heap;
         std::atomic_size_t available_blk_count;
         uint64_t m_total_blks{0}; // initlized during boot, and will not change during runtime;
         uint32_t size() const { return m_heap.size(); }
+    };
+
+    struct PGChunkCollection {
+        std::mutex mtx;
+        std::vector< std::shared_ptr< ExtendedVChunk > > m_pg_chunks;
+        std::atomic_size_t available_num_chunks;
+        std::atomic_size_t available_blk_count;
+        uint64_t m_total_blks{0}; // initlized during boot, and will not change during runtime;
     };
 
     void add_chunk(csharedChunk&) override;
@@ -52,16 +71,13 @@ public:
 
     csharedChunk select_chunk([[maybe_unused]] homestore::blk_count_t nblks, const homestore::blk_alloc_hints& hints);
 
-    // this function will be used by GC flow or recovery flow to mark one specific chunk to be busy, caller should be
-    // responsible to use release_chunk() interface to release it when no longer to use the chunk anymore.
-    csharedChunk select_specific_chunk(const pg_id_t pg_id, const chunk_num_t);
+    // this function will be used by create shard or recovery flow to mark one specific chunk to be busy, caller should
+    // be responsible to use release_chunk() interface to release it when no longer to use the chunk anymore.
+    csharedChunk select_specific_chunk(const pg_id_t pg_id, const chunk_num_t v_chunk_id);
 
-    // this function will be used by GC flow to select a chunk for GC
-    csharedChunk most_defrag_chunk();
-
-    // this function is used to return a chunk back to ChunkSelector when sealing a shard, and will only be used by
-    // Homeobject.
-    void release_chunk(const pg_id_t pg_id, const chunk_num_t);
+    // This function returns a chunk back to ChunkSelector.
+    // It is used in two scenarios: 1. seal shard  2. create shard rollback
+    bool release_chunk(const pg_id_t pg_id, const chunk_num_t v_chunk_id);
 
     /**
      * select chunks for pg, chunks need to be in same pdev.
@@ -70,26 +86,27 @@ public:
      * @param pg_size The fix pg size.
      * @return An optional uint32_t value representing num_chunk, or std::nullopt if no space left.
      */
-    std::optional< uint32_t > select_chunks_for_pg(pg_id_t pg_id, u_int64_t pg_size);
+    std::optional< uint32_t > select_chunks_for_pg(pg_id_t pg_id, uint64_t pg_size);
 
-    std::shared_ptr< const std::vector <chunk_num_t> > get_pg_chunks(pg_id_t pg_id) const;
+    // this function is used for pg info superblk persist v_chunk_id <-> p_chunk_id
+    std::shared_ptr< const std::vector< chunk_num_t > > get_pg_chunks(pg_id_t pg_id) const;
+
+    /**
+     * pop pg top chunk
+     *
+     * @param pg_id The ID of the pg.
+     * @return An optional chunk_num_t value representing v_chunk_id, or std::nullopt if no space left.
+     */
+    std::optional< chunk_num_t > get_most_available_blk_chunk(pg_id_t pg_id) const;
 
     // this should be called on each pg meta blk found
-    void set_pg_chunks(pg_id_t pg_id, std::vector<chunk_num_t>&& chunk_ids);
+    bool recover_pg_chunks(pg_id_t pg_id, std::vector< chunk_num_t >&& p_chunk_ids);
 
     // this should be called after all pg meta blk recovered
     void recover_per_dev_chunk_heap();
 
     // this should be called after ShardManager is initialized and get all the open shards
-    void recover_pg_chunk_heap(pg_id_t pg_id, const std::unordered_set< chunk_num_t >& excludingChunks);
-
-    /**
-     * Retrieves the block allocation hints for a given chunk.
-     *
-     * @param chunk_id The ID of the chunk.
-     * @return The block allocation hints for the specified chunk.
-     */
-    homestore::blk_alloc_hints chunk_to_hints(chunk_num_t chunk_id) const;
+    bool recover_pg_chunks_states(pg_id_t pg_id, const std::unordered_set< chunk_num_t >& excluding_v_chunk_ids);
 
     /**
      * Returns the number of available blocks of the given device id.
@@ -97,7 +114,7 @@ public:
      * @param dev_id (optional) The device ID. if nullopt, it returns the maximum available blocks among all devices.
      * @return The number of available blocks.
      */
-    uint64_t avail_blks(std::optional< uint32_t > dev_id) const;
+    uint64_t avail_blks(pg_id_t pg_id) const;
 
     /**
      * Returns the total number of blocks of the given device;
@@ -116,12 +133,12 @@ public:
     uint32_t most_avail_num_chunks() const;
 
     /**
-     * Returns the number of available chunks for a given device ID.
+     * Returns the number of available chunks for a given pg id.
      *
-     * @param dev_id The device ID.
+     * @param pg_id The pg id.
      * @return The number of available chunks.
      */
-    uint32_t avail_num_chunks(uint32_t dev_id) const;
+    uint32_t avail_num_chunks(pg_id_t pg_id) const;
 
     /**
      * @brief Returns the total number of chunks.
@@ -135,24 +152,15 @@ public:
     uint32_t get_chunk_size() const;
 
 private:
-    std::unordered_map< uint32_t, std::shared_ptr< ChunkHeap > > m_per_dev_heap;
-    std::unordered_map< pg_id_t, std::shared_ptr< ChunkHeap > > m_per_pg_heap;
-
-    // These mappings ensure "identical layout" by providing bidirectional indexing between virtual and real chunk IDs.
-    // m_v2r_chunk_map: Maps each pg_id to a vector of real chunk IDs (r_chunk_id). The index in the vector corresponds to the virtual chunk ID (v_chunk_id).
-    std::unordered_map< pg_id_t, std::shared_ptr< std::vector <chunk_num_t> > > m_v2r_chunk_map;
-    // m_r2v_chunk_map: Maps each pg_id to a map that inversely maps real chunk IDs (r_chunk_id) to virtual chunk IDs (v_chunk_id).
-    std::unordered_map< pg_id_t, std::shared_ptr< ChunkIdMap > > m_r2v_chunk_map;
-
-    // hold all the chunks , selected or not
-    std::unordered_map< chunk_num_t, csharedChunk > m_chunks;
-
-    mutable std::shared_mutex m_chunk_selector_mtx;
     void add_chunk_internal(const chunk_num_t, bool add_to_heap = true);
 
-    VChunkDefragHeap m_defrag_heap;
-    std::mutex m_defrag_mtx;
+private:
+    std::unordered_map< uint32_t, std::shared_ptr< ChunkHeap > > m_per_dev_heap;
 
-    void remove_chunk_from_defrag_heap(const chunk_num_t);
+    std::unordered_map< pg_id_t, std::shared_ptr< PGChunkCollection > > m_per_pg_chunks;
+    // hold all the chunks , selected or not
+    std::unordered_map< chunk_num_t, homestore::cshared< ExtendedVChunk > > m_chunks;
+
+    mutable std::shared_mutex m_chunk_selector_mtx;
 };
 } // namespace homeobject

--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -351,10 +351,10 @@ HSHomeObject::blob_put_get_blk_alloc_hints(sisl::blob const& header, cintrusive<
     }
 
     auto hs_shard = d_cast< HS_Shard* >((*shard_iter->second).get());
-    BLOGD(msg_header->shard_id, "n/a", "Picked chunk_id={}", hs_shard->sb_->chunk_id);
+    BLOGD(msg_header->shard_id, "n/a", "Picked p_chunk_id={}", hs_shard->sb_->p_chunk_id);
 
     homestore::blk_alloc_hints hints;
-    hints.chunk_id_hint = hs_shard->sb_->chunk_id;
+    hints.chunk_id_hint = hs_shard->sb_->p_chunk_id;
     return hints;
 }
 

--- a/src/lib/homestore_backend/tests/hs_pg_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_pg_tests.cpp
@@ -46,6 +46,44 @@ TEST_F(HomeObjectFixture, PGStatsTest) {
     LOGINFO("HomeObj stats: {}", stats.to_string());
 }
 
+TEST_F(HomeObjectFixture, PGExceedSpaceTest) {
+    LOGINFO("HomeObject replica={} setup completed", g_helper->replica_num());
+    pg_id_t pg_id{1};
+    if (0 == g_helper->replica_num()) { // leader
+        auto memebers = g_helper->members();
+        auto name = g_helper->name();
+        auto info = homeobject::PGInfo(pg_id);
+        info.size = 500 * Gi; // execced local available space
+        for (const auto& member : memebers) {
+            if (0 == member.second) {
+                // by default, leader is the first member
+                info.members.insert(homeobject::PGMember{member.first, name + std::to_string(member.second), 1});
+            } else {
+                info.members.insert(homeobject::PGMember{member.first, name + std::to_string(member.second), 0});
+            }
+        }
+        auto p = _obj_inst->pg_manager()->create_pg(std::move(info)).get();
+        ASSERT_TRUE(p.hasError());
+        PGError error = p.error();
+        ASSERT_EQ(PGError::NO_SPACE_LEFT, error);
+    } else {
+        auto start_time = std::chrono::steady_clock::now();
+        bool res = true;
+        // follower need to wait for pg creation
+        while (!pg_exist(pg_id)) {
+            auto current_time = std::chrono::steady_clock::now();
+            auto duration = std::chrono::duration_cast< std::chrono::seconds >(current_time - start_time).count();
+            if (duration >= 20) {
+                LOGINFO("Failed to create pg {} at follower", pg_id);
+                res = false;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+        ASSERT_FALSE(res);
+    }
+}
+
 TEST_F(HomeObjectFixture, PGRecoveryTest) {
     // create 10 pg
     for (pg_id_t i = 1; i < 11; i++) {

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -40,7 +40,6 @@ public:
 
     blk_num_t get_total_blks() const { return m_available_blks; }
     void set_chunk_id(uint16_t chunk_id) { m_chunk_id = chunk_id; }
-    const std::shared_ptr< Chunk > get_internal_chunk() { return shared_from_this(); }
     uint64_t size() const { return 1 * Mi; }
 
     Chunk(uint32_t pdev_id, uint16_t chunk_id, uint32_t available_blks, uint32_t defrag_nblks) {
@@ -75,14 +74,19 @@ blk_num_t VChunk::get_total_blks() const { return m_internal_chunk->get_total_bl
 
 uint64_t VChunk::size() const { return m_internal_chunk->size(); }
 
-cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk->get_internal_chunk(); }
+cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk; }
 
 } // namespace homestore
 
+using homeobject::ChunkState;
 using homeobject::csharedChunk;
 using homeobject::HeapChunkSelector;
+using homeobject::pg_id_t;
 using homestore::Chunk;
 using homestore::chunk_num_t;
+
+const pg_id_t FAKE_PG_ID = UINT16_MAX;
+const chunk_num_t FAKE_CHUNK_ID = UINT16_MAX;
 
 class HeapChunkSelectorTest : public ::testing::Test {
 protected:
@@ -101,41 +105,40 @@ protected:
     };
 
     void prepare_pg() {
-        const uint32_t chunk_size = HCS.get_chunk_size(); // may problem
+        const uint32_t chunk_size = HCS.get_chunk_size();
         const u_int64_t pg_size = chunk_size * 3;
         for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
-            HCS.select_chunks_for_pg(pg_id, pg_size);
+            ASSERT_EQ(HCS.select_chunks_for_pg(pg_id, pg_size), 3);
             uint32_t last_pdev_id = 0;
             // test pg heap
-            auto pg_heap_it = HCS.m_per_pg_heap.find(pg_id);
-            ASSERT_NE(pg_heap_it, HCS.m_per_pg_heap.end());
-            ASSERT_EQ(pg_heap_it->second->size(), 3);
+            auto pg_it = HCS.m_per_pg_chunks.find(pg_id);
+            ASSERT_NE(pg_it, HCS.m_per_pg_chunks.end());
+            auto pg_chunk_collection = pg_it->second;
+            auto& pg_chunks = pg_chunk_collection->m_pg_chunks;
+            ASSERT_EQ(pg_chunk_collection->available_num_chunks, 3);
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2 + 3);
+            ASSERT_EQ(pg_chunk_collection->m_total_blks, 1 + 2 + 3);
 
-            // test chunk_map
-            auto v2r_chunk_map_it = HCS.m_v2r_chunk_map.find(pg_id);
-            ASSERT_NE(v2r_chunk_map_it, HCS.m_v2r_chunk_map.end());
-            ASSERT_EQ(v2r_chunk_map_it->second->size(), 3);
-
-            auto r2v_chunk_map_it = HCS.m_r2v_chunk_map.find(pg_id);
-            ASSERT_NE(r2v_chunk_map_it, HCS.m_r2v_chunk_map.end());
-            ASSERT_EQ(r2v_chunk_map_it->second->size(), 3);
             for (int i = 0; i < 3; ++i) {
-                auto r_chunk_id = v2r_chunk_map_it->second->at(i);
-                ASSERT_EQ(i, r2v_chunk_map_it->second->at(r_chunk_id));
-                auto pdev_id = HCS.m_chunks[r_chunk_id]->get_pdev_id();
+                // test chunk information
+                auto p_chunk_id = pg_chunks[i]->get_chunk_id();
+                ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_pg_id.value(), pg_id);
+                ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_v_chunk_id.value(), i);
+                ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::AVAILABLE);
+                // test pg chunks must belong to same pdev
+                auto pdev_id = HCS.m_chunks[p_chunk_id]->get_pdev_id();
                 if (last_pdev_id != 0) {
                     ASSERT_EQ(last_pdev_id, pdev_id);
                 } else {
                     last_pdev_id = pdev_id;
                 }
-
+                // pdev heap should be empty at this point because all chunks have already been given to pg.
                 auto pdev_it = HCS.m_per_dev_heap.find(pdev_id);
                 ASSERT_NE(pdev_it, HCS.m_per_dev_heap.end());
                 ASSERT_EQ(pdev_it->second->size(), 0);
             }
         }
     }
-
 
 public:
     HeapChunkSelector HCS;
@@ -147,6 +150,59 @@ TEST_F(HeapChunkSelectorTest, test_for_each_chunk) {
     ASSERT_EQ(size.load(), 18);
 }
 
+TEST_F(HeapChunkSelectorTest, test_identical_layout) {
+    const homestore::blk_count_t count = 1;
+    homestore::blk_alloc_hints hints;
+    for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
+        chunk_num_t p_chunk_id = 0;
+        auto pg_chunk_collection = HCS.m_per_pg_chunks[pg_id];
+        auto start_available_blk_count = 1 + 2 + 3;
+        for (int j = 3; j > 0; --j) {
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count);
+
+            const auto v_chunkID = HCS.get_most_available_blk_chunk(pg_id);
+            ASSERT_TRUE(v_chunkID.has_value());
+            p_chunk_id = pg_chunk_collection->m_pg_chunks[v_chunkID.value()]->get_chunk_id();
+            ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
+            ASSERT_EQ(pg_chunk_collection->available_num_chunks, j - 1);
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count - j);
+
+            const auto v_chunkID2 = HCS.m_chunks[p_chunk_id]->m_v_chunk_id;
+            ASSERT_TRUE(v_chunkID2.has_value());
+            ASSERT_EQ(v_chunkID.value(), v_chunkID2.value());
+            hints.application_hint = ((uint64_t)pg_id << 16) | v_chunkID.value();
+
+            // mock leader on_commit
+            ASSERT_NE(HCS.select_chunk(count, hints), nullptr);
+            ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
+            ASSERT_EQ(pg_chunk_collection->available_num_chunks, j - 1);
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count - j);
+
+            // mock leader rollback or on_error
+            ASSERT_TRUE(HCS.release_chunk(pg_id, v_chunkID.value()));
+            ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::AVAILABLE);
+            ASSERT_EQ(pg_chunk_collection->available_num_chunks, j);
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count);
+
+            // mock follower rollback or on_error
+            ASSERT_TRUE(HCS.release_chunk(pg_id, v_chunkID.value()));
+            ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::AVAILABLE);
+            ASSERT_EQ(pg_chunk_collection->available_num_chunks, j);
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count);
+
+            // mock follower on_commit
+            ASSERT_NE(HCS.select_chunk(count, hints), nullptr); // leader select
+            ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
+            ASSERT_EQ(pg_chunk_collection->available_num_chunks, j - 1);
+            ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count - j);
+
+            start_available_blk_count -= j;
+        }
+        // all chunks have been given out
+        ASSERT_FALSE(HCS.get_most_available_blk_chunk(pg_id).has_value());
+    }
+}
+
 TEST_F(HeapChunkSelectorTest, test_select_chunk) {
     homestore::blk_count_t count = 1;
     homestore::blk_alloc_hints hints;
@@ -154,84 +210,66 @@ TEST_F(HeapChunkSelectorTest, test_select_chunk) {
     ASSERT_EQ(chunk, nullptr);
 
     for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
-        hints.pdev_id_hint = pg_id; // tmp bypass using pdev_id_hint present pg_id
         for (int j = 3; j > 0; --j) {
+            chunk_num_t v_chunk_id = 3 - j;
+            hints.application_hint = ((uint64_t)pg_id << 16) | v_chunk_id;
             auto chunk = HCS.select_chunk(count, hints);
             ASSERT_NE(chunk, nullptr);
-            ASSERT_EQ(chunk->get_pdev_id(), pg_id);
+            ASSERT_EQ(chunk->get_pdev_id(), pg_id); // in this ut, pg_id is same as pdev id
             ASSERT_EQ(chunk->available_blks(), j);
         }
     }
 }
 
+TEST_F(HeapChunkSelectorTest, test_select_specific_chunk_and_release_chunk) {
+    for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
+        // test fake
+        ASSERT_FALSE(HCS.release_chunk(FAKE_PG_ID, FAKE_CHUNK_ID));
+        ASSERT_FALSE(HCS.release_chunk(pg_id, FAKE_CHUNK_ID));
+        ASSERT_EQ(nullptr, HCS.select_specific_chunk(FAKE_PG_ID, FAKE_CHUNK_ID));
+        ASSERT_EQ(nullptr, HCS.select_specific_chunk(pg_id, FAKE_CHUNK_ID));
 
-TEST_F(HeapChunkSelectorTest, test_select_specific_chunk) {
-    const uint16_t pg_id = 1;
-    auto chunk_ids = HCS.get_pg_chunks(pg_id);
-    ASSERT_NE(chunk_ids, nullptr);
-    const chunk_num_t chunk_id = chunk_ids->at(0);
+        auto chunk_ids = HCS.get_pg_chunks(pg_id);
+        ASSERT_NE(chunk_ids, nullptr);
+        const chunk_num_t v_chunk_id = 0;
+        const chunk_num_t p_chunk_id = chunk_ids->at(v_chunk_id);
 
-    auto chunk = HCS.select_specific_chunk(pg_id, chunk_id);
-    ASSERT_EQ(chunk->get_chunk_id(), chunk_id);
-    auto pdev_id = chunk->get_pdev_id();
+        auto pg_chunk_collection = HCS.m_per_pg_chunks[pg_id];
+        auto chunk = HCS.select_specific_chunk(pg_id, v_chunk_id);
+        ASSERT_NE(nullptr, chunk);
+        ASSERT_EQ(chunk->get_chunk_id(), p_chunk_id);
+        ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
+        ASSERT_EQ(pg_chunk_collection->available_num_chunks, 2);
+        ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2);
 
-    // make sure pg chunk map
-    auto pg_heap_it = HCS.m_per_pg_heap.find(pg_id);
-    ASSERT_NE(pg_heap_it, HCS.m_per_pg_heap.end());
-    ASSERT_EQ(pg_heap_it->second->size(), 2);
+        // test select an INUSE chunk
+        chunk = HCS.select_specific_chunk(pg_id, v_chunk_id);
+        ASSERT_NE(nullptr, chunk);
+        ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
+        ASSERT_EQ(pg_chunk_collection->available_num_chunks, 2);
+        ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2);
 
-    // test chunk_map stable
-    auto v2r_chunk_map_it = HCS.m_v2r_chunk_map.find(pg_id);
-    ASSERT_NE(v2r_chunk_map_it, HCS.m_v2r_chunk_map.end());
-    ASSERT_EQ(v2r_chunk_map_it->second->size(), 3);
+        // release this chunk to HeapChunkSelector
+        ASSERT_TRUE(HCS.release_chunk(pg_id, v_chunk_id));
+        ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::AVAILABLE);
+        ASSERT_EQ(pg_chunk_collection->available_num_chunks, 3);
+        ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2 + 3);
 
-    auto r2v_chunk_map_it = HCS.m_r2v_chunk_map.find(pg_id);
-    ASSERT_NE(r2v_chunk_map_it, HCS.m_r2v_chunk_map.end());
-    ASSERT_EQ(r2v_chunk_map_it->second->size(), 3);
+        // test release an AVAILABLE chunk
+        ASSERT_TRUE(HCS.release_chunk(pg_id, v_chunk_id));
+        ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::AVAILABLE);
+        ASSERT_EQ(pg_chunk_collection->available_num_chunks, 3);
+        ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2 + 3);
 
-    // select the rest chunks to make sure specific chunk does not exist in HeapChunkSelector anymore.
-    homestore::blk_count_t count = 1;
-    homestore::blk_alloc_hints hints;
-    hints.pdev_id_hint = pg_id;
-    for (int j = 2; j > 0; --j) {
-        auto chunk = HCS.select_chunk(count, hints);
-        ASSERT_EQ(chunk->get_pdev_id(), pdev_id);
+        // select again
+        chunk = HCS.select_specific_chunk(pg_id, v_chunk_id);
+        ASSERT_NE(nullptr, chunk);
+        ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
+        ASSERT_EQ(pg_chunk_collection->available_num_chunks, 2);
+        ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2);
+        ASSERT_EQ(pg_id, chunk->get_pdev_id()); // in this ut, pg_id is same as pdev id
+        ASSERT_EQ(p_chunk_id, chunk->get_chunk_id());
     }
-
-    // release this chunk to HeapChunkSelector
-    HCS.release_chunk(pg_id, chunk_id);
-    chunk = HCS.select_chunk(1, hints);
-    ASSERT_EQ(1, chunk->get_pdev_id());
-    ASSERT_EQ(chunk_id, chunk->get_chunk_id());
-
-}
-
-
-TEST_F(HeapChunkSelectorTest, test_release_chunk) {
-    homestore::blk_count_t count = 1;
-    homestore::blk_alloc_hints hints;
-    const uint16_t pg_id = 1;
-    hints.pdev_id_hint = pg_id;
-    auto chunk1 = HCS.select_chunk(count, hints);
-    auto pdev_id = chunk1->get_pdev_id();
-
-    ASSERT_EQ(chunk1->get_pdev_id(), pdev_id);
-    ASSERT_EQ(chunk1->available_blks(), 3);
-
-    auto chunk2 = HCS.select_chunk(count, hints);
-    ASSERT_EQ(chunk2->get_pdev_id(), pdev_id);
-    ASSERT_EQ(chunk2->available_blks(), 2);
-
-    HCS.release_chunk(pg_id, chunk1->get_chunk_id());
-    HCS.release_chunk(pg_id, chunk2->get_chunk_id());
-
-    chunk1 = HCS.select_chunk(count, hints);
-    ASSERT_EQ(chunk1->get_pdev_id(), pdev_id);
-    ASSERT_EQ(chunk1->available_blks(), 3);
-
-    chunk2 = HCS.select_chunk(count, hints);
-    ASSERT_EQ(chunk2->get_pdev_id(), pdev_id);
-    ASSERT_EQ(chunk2->available_blks(), 2);
 }
 
 TEST_F(HeapChunkSelectorTest, test_recovery) {
@@ -242,49 +280,81 @@ TEST_F(HeapChunkSelectorTest, test_recovery) {
     HCS_recovery.add_chunk(std::make_shared< Chunk >(2, 4, 1, 6));
     HCS_recovery.add_chunk(std::make_shared< Chunk >(2, 5, 2, 5));
     HCS_recovery.add_chunk(std::make_shared< Chunk >(2, 6, 3, 4));
+    HCS_recovery.add_chunk(std::make_shared< Chunk >(3, 7, 1, 3));
+    HCS_recovery.add_chunk(std::make_shared< Chunk >(3, 8, 2, 2));
+    HCS_recovery.add_chunk(std::make_shared< Chunk >(3, 9, 3, 1));
 
-    std::vector<chunk_num_t> chunk_ids {1,2,3};
-    const uint16_t pg_id = 1;
-    // test recover chunk map
-    HCS_recovery.set_pg_chunks(pg_id, std::move(chunk_ids));
-    auto v2r_chunk_map_it = HCS_recovery.m_v2r_chunk_map.find(pg_id);
-    ASSERT_NE(v2r_chunk_map_it, HCS_recovery.m_v2r_chunk_map.end());
-    ASSERT_EQ(v2r_chunk_map_it->second->size(), 3);
+    // on_pg_meta_blk_found
+    for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
+        std::vector< chunk_num_t > chunk_ids{1, 2};
+        std::vector< chunk_num_t > chunk_ids_for_twice{1, 2};
+        std::vector< chunk_num_t > chunk_ids_not_valid{1, 20};
+        std::vector< chunk_num_t > chunk_ids_not_same_pdev{1, 6};
+        for (chunk_num_t j = 0; j < 2; ++j) {
+            chunk_ids[j] += (pg_id - 1) * 3;
+            chunk_ids_for_twice[j] += (pg_id - 1) * 3;
+            chunk_ids_not_valid[j] += (pg_id - 1) * 3;
+            chunk_ids_not_same_pdev[j] += ((pg_id - 1) * 3) % 9;
+        }
 
-    auto r2v_chunk_map_it = HCS_recovery.m_r2v_chunk_map.find(pg_id);
-    ASSERT_NE(r2v_chunk_map_it, HCS_recovery.m_r2v_chunk_map.end());
-    ASSERT_EQ(r2v_chunk_map_it->second->size(), 3);
-    // test recover pdev map
-    HCS_recovery.recover_per_dev_chunk_heap();
-    auto pdev_it = HCS_recovery.m_per_dev_heap.find(1);
-    ASSERT_NE(pdev_it, HCS_recovery.m_per_dev_heap.end());
-    ASSERT_EQ(pdev_it->second->size(), 0);
+        // test recover chunk map
+        ASSERT_FALSE(HCS_recovery.recover_pg_chunks(pg_id, std::move(chunk_ids_not_valid)));
+        ASSERT_FALSE(HCS_recovery.recover_pg_chunks(pg_id, std::move(chunk_ids_not_same_pdev)));
 
-    pdev_it = HCS_recovery.m_per_dev_heap.find(2);
-    ASSERT_NE(pdev_it, HCS_recovery.m_per_dev_heap.end());
-    ASSERT_EQ(pdev_it->second->size(), 3);
-    auto &pdev_heap = pdev_it->second->m_heap;
-    auto vchunk = homestore::VChunk(nullptr);
-    for (int i = 6; i > 3; --i) {
-        vchunk = pdev_heap.top();
-        pdev_heap.pop();
-        ASSERT_EQ(vchunk.get_chunk_id(), i);
+        ASSERT_TRUE(HCS_recovery.recover_pg_chunks(pg_id, std::move(chunk_ids)));
+        // can't set pg chunks twice
+        ASSERT_FALSE(HCS_recovery.recover_pg_chunks(pg_id, std::move(chunk_ids_for_twice)));
+
+        auto pg_it = HCS_recovery.m_per_pg_chunks.find(pg_id);
+        ASSERT_NE(pg_it, HCS_recovery.m_per_pg_chunks.end());
+        auto pg_chunk_collection = pg_it->second;
+        ASSERT_EQ(pg_chunk_collection->m_pg_chunks.size(), 2);
+        for (chunk_num_t v_chunk_id = 0; v_chunk_id < 2; ++v_chunk_id) {
+            ASSERT_EQ(pg_chunk_collection->m_pg_chunks[v_chunk_id]->m_pg_id, pg_id);
+            ASSERT_EQ(pg_chunk_collection->m_pg_chunks[v_chunk_id]->m_v_chunk_id, v_chunk_id);
+            ASSERT_EQ(pg_chunk_collection->m_pg_chunks[v_chunk_id]->get_chunk_id(), chunk_ids[v_chunk_id]);
+        }
     }
 
-    // test recover pg heap
-    std::unordered_set< homestore::chunk_num_t > excluding_chunks;
-    excluding_chunks.emplace(1);
-    HCS_recovery.recover_pg_chunk_heap(pg_id, excluding_chunks);
-    auto pg_heap_it = HCS_recovery.m_per_pg_heap.find(pg_id);
-    ASSERT_NE(pg_heap_it, HCS_recovery.m_per_pg_heap.end());
-    ASSERT_EQ(pg_heap_it->second->size(), 2);
+    //  on_pg_meta_blk_recover_completed
+    HCS_recovery.recover_per_dev_chunk_heap();
+    for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
+        // test recover pdev map size
+        auto pdev_it = HCS_recovery.m_per_dev_heap.find(pg_id);
+        ASSERT_NE(pdev_it, HCS_recovery.m_per_dev_heap.end());
+        ASSERT_EQ(pdev_it->second->size(), 1); // 1 = 3(all) - 2(pg)
 
-    homestore::blk_alloc_hints hints;
-    hints.pdev_id_hint = pg_id;
-    for (int j = 3; j > 1; --j) {
-        auto chunk = HCS_recovery.select_chunk(1, hints);
-        ASSERT_EQ(chunk->get_pdev_id(), 1);
-        ASSERT_EQ(chunk->available_blks(), j);
+        auto& pdev_heap = pdev_it->second->m_heap;
+        auto chunk = pdev_heap.top();
+        ASSERT_EQ(chunk->get_chunk_id(), 3 + (pg_id - 1) * 3);
+    }
+
+    // on_shard_meta_blk_recover_completed
+    for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
+        // test recover pg heap
+        std::unordered_set< homestore::chunk_num_t > excluding_chunks;
+        excluding_chunks.emplace(0);
+
+        ASSERT_FALSE(HCS_recovery.recover_pg_chunks_states(FAKE_PG_ID, excluding_chunks));
+        ASSERT_TRUE(HCS_recovery.recover_pg_chunks_states(pg_id, excluding_chunks));
+
+        auto pg_it = HCS_recovery.m_per_pg_chunks.find(pg_id);
+        ASSERT_NE(pg_it, HCS_recovery.m_per_pg_chunks.end());
+        auto pg_chunk_collection = pg_it->second;
+        ASSERT_EQ(pg_chunk_collection->m_pg_chunks.size(), 2); // size wont change
+        ASSERT_EQ(pg_chunk_collection->available_num_chunks, 1);
+        ASSERT_EQ(pg_chunk_collection->available_blk_count, 2); // only left v_chunk_id=1
+
+        ASSERT_EQ(pg_chunk_collection->m_pg_chunks[0]->m_state, ChunkState::INUSE);
+        ASSERT_EQ(pg_chunk_collection->m_pg_chunks[1]->m_state, ChunkState::AVAILABLE);
+
+        const auto v_chunkID = HCS_recovery.get_most_available_blk_chunk(pg_id);
+        ASSERT_TRUE(v_chunkID.has_value());
+        auto chunk = HCS_recovery.select_specific_chunk(pg_id, v_chunkID.value());
+        ASSERT_NE(chunk, nullptr);
+        ASSERT_EQ(chunk->get_pdev_id(), pg_id);
+        ASSERT_EQ(chunk->available_blks(), 2);
+        ASSERT_EQ(pg_chunk_collection->m_pg_chunks[1]->m_state, ChunkState::INUSE);
     }
 }
 


### PR DESCRIPTION
1. Implement an identical shard layout using `homestore::blk_alloc_hints`, specifically employing `pdev_id_hint` to store pg id and physical chunk id.
2. Enhance defensive checks in ChunkSelector to validate inputs and handle exceptions. Correct from r_chunk_id to p_chunk_id
3. Adapt unit tests and add `PGExceedSpaceTest`