### PR TITLE
Fix HeapChunkSelector::get_most_available_blk_chunk

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.9"
+    version = "2.1.10"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -60,6 +60,11 @@ PGManager::NullAsyncResult HSHomeObject::_create_pg(PGInfo&& pg_info, std::set< 
     auto pg_id = pg_info.id;
     if (auto lg = std::shared_lock(_pg_lock); _pg_map.end() != _pg_map.find(pg_id)) return folly::Unit();
 
+    if (pg_info.size == 0) {
+        LOGW("Not supported to create empty PG, pg_id {}, pg_size {}", pg_id, pg_info.size);
+        return folly::makeUnexpected(PGError::INVALID_ARG);
+    }
+
     const auto most_avail_num_chunks = chunk_selector()->most_avail_num_chunks();
     const auto chunk_size = chunk_selector()->get_chunk_size();
     const auto needed_num_chunks = sisl::round_down(pg_info.size, chunk_size) / chunk_size;


### PR DESCRIPTION
Fix HeapChunkSelector::get_most_available_blk_chunk

1. Add check to ensure max_it points to an available chunk.
   If not, it indicates there are no available chunks left.
2. Add safeguards in the create and recover pg paths to ensure
   the pg size cannot be zero.