### PR TITLE
Fix and Improve `fix pg size & shard identical layout`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.12"
+    version = "2.1.13"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -98,6 +98,8 @@ private:
 //
 // This should assert if we can not initialize HomeStore.
 //
+uint64_t HSHomeObject::_hs_chunk_size = HS_CHUNK_SIZE;
+
 DevType HSHomeObject::get_device_type(string const& devname) {
     const iomgr::drive_type dtype = iomgr::DriveInterface::get_drive_type(devname);
     if (dtype == iomgr::drive_type::block_hdd || dtype == iomgr::drive_type::file_on_hdd) { return DevType::HDD; }
@@ -168,7 +170,8 @@ void HSHomeObject::init_homestore() {
                 {HS_SERVICE::REPLICATION,
                  hs_format_params{.dev_type = HSDevType::Data,
                                   .size_pct = 99.0,
-                                  .num_chunks = 60000,
+                                  .num_chunks = 0,
+                                  .chunk_size = _hs_chunk_size,
                                   .block_size = _data_block_size,
                                   .alloc_type = blk_allocator_type_t::append,
                                   .chunk_sel_type = chunk_selector_type_t::CUSTOM}},
@@ -185,7 +188,8 @@ void HSHomeObject::init_homestore() {
                 {HS_SERVICE::REPLICATION,
                  hs_format_params{.dev_type = run_on_type,
                                   .size_pct = 79.0,
-                                  .num_chunks = 60000,
+                                  .num_chunks = 0,
+                                  .chunk_size = _hs_chunk_size,
                                   .block_size = _data_block_size,
                                   .alloc_type = blk_allocator_type_t::append,
                                   .chunk_sel_type = chunk_selector_type_t::CUSTOM}},

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -32,11 +32,14 @@ BlobError toBlobError(homestore::ReplServiceError const&);
 ShardError toShardError(homestore::ReplServiceError const&);
 
 class HSHomeObject : public HomeObjectImpl {
+private:
     /// NOTE: Be wary to change these as they effect on-disk format!
     inline static auto const _svc_meta_name = std::string("HomeObject");
     inline static auto const _pg_meta_name = std::string("PGManager");
     inline static auto const _shard_meta_name = std::string("ShardManager");
+    static constexpr uint64_t HS_CHUNK_SIZE = 2 * Gi;
     static constexpr uint32_t _data_block_size = 1024;
+    static uint64_t _hs_chunk_size;
     ///
 
     /// Overridable Helpers
@@ -244,7 +247,7 @@ public:
 
     struct HS_Shard : public Shard {
         homestore::superblk< shard_info_superblk > sb_;
-        HS_Shard(ShardInfo info, homestore::chunk_num_t p_chunk_id);
+        HS_Shard(ShardInfo info, homestore::chunk_num_t p_chunk_id, homestore::chunk_num_t v_chunk_id);
         HS_Shard(homestore::superblk< shard_info_superblk >&& sb);
         ~HS_Shard() override = default;
 

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -167,7 +167,10 @@ ReplicationStateMachine::get_blk_alloc_hints(sisl::blob const& header, uint32_t 
 
     case ReplicationMessageType::SEAL_SHARD_MSG: {
         auto p_chunkID = home_object_->get_shard_p_chunk_id(msg_header->shard_id);
-        RELEASE_ASSERT(p_chunkID.has_value(), "unknown shard id to get binded chunk");
+        if (!p_chunkID.has_value()) {
+            LOGW("shard does not exist, underlying engine will retry this later", msg_header->shard_id);
+            return folly::makeUnexpected(homestore::ReplServiceError::RESULT_NOT_EXIST_YET);
+        }
         homestore::blk_alloc_hints hints;
         hints.chunk_id_hint = p_chunkID.value();
         return hints;

--- a/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
+++ b/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
@@ -43,6 +43,7 @@ namespace bip = boost::interprocess;
 using namespace homeobject;
 
 #define INVALID_UINT64_ID UINT64_MAX
+#define INVALID_CHUNK_NUM UINT16_MAX
 
 namespace test_common {
 
@@ -56,6 +57,7 @@ protected:
                 sync_point_num_ = sync_point;
                 homeobject_replica_count_ = 0;
                 uint64_id_ = INVALID_UINT64_ID;
+                v_chunk_id_ = INVALID_CHUNK_NUM;
                 cv_.notify_all();
             } else {
                 cv_.wait(lg, [this, sync_point]() { return sync_point_num_ == sync_point; });
@@ -72,6 +74,16 @@ protected:
             return uint64_id_;
         }
 
+        void set_v_chunk_id(homestore::chunk_num_t input_v_chunk_id) {
+            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
+            v_chunk_id_ = input_v_chunk_id;
+        }
+
+        homestore::chunk_num_t get_v_chunk_id() {
+            std::unique_lock< bip::interprocess_mutex > lg(mtx_);
+            return v_chunk_id_;
+        }
+
     private:
         bip::interprocess_mutex mtx_;
         bip::interprocess_condition cv_;
@@ -79,6 +91,9 @@ protected:
 
         // the following variables are used to share shard_id and blob_id among different replicas
         uint64_t uint64_id_{0};
+
+        // used to verify identical layout
+        homestore::chunk_num_t v_chunk_id_{0};
 
         // the nth synchronization point, that is how many times different replicas have synced
         uint64_t sync_point_num_{UINT64_MAX};
@@ -256,6 +271,8 @@ public:
     void sync() { ipc_data_->sync(sync_point_num++, total_replicas_nums_); }
     void set_uint64_id(uint64_t uint64_id) { ipc_data_->set_uint64_id(uint64_id); }
     uint64_t get_uint64_id() { return ipc_data_->get_uint64_id(); }
+    void set_v_chunk_id(homestore::chunk_num_t v_chunk_id) { ipc_data_->set_v_chunk_id(v_chunk_id); }
+    homestore::chunk_num_t get_v_chunk_id() { return ipc_data_->get_v_chunk_id(); }
 
     void check_and_kill(int port) {
         std::string command = "lsof -t -i:" + std::to_string(port);

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -108,7 +108,7 @@ protected:
         const uint32_t chunk_size = HCS.get_chunk_size();
         const u_int64_t pg_size = chunk_size * 3;
         for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
-            // not supported to create empty pg
+            // not supported to create pg which pg_size < chunk_size
             ASSERT_FALSE(HCS.select_chunks_for_pg(pg_id, 0).has_value());
             ASSERT_EQ(HCS.select_chunks_for_pg(pg_id, pg_size).value(), 3);
             uint32_t last_pdev_id = 0;


### PR DESCRIPTION
Bug Fixes:
- Resolved issues in create_shard and seal_shard functions to ensure correct shard management. Enhancements:
- Added validation to prevent creation of placement groups with sizes smaller than the chunk size. Test Improvements:
- pg test:
	- Added tests to verify that creating a placement group with a size smaller than the chunk size results in failure.
- shard test:
	- Created shard but shard size is larger than pg space left which should be failed.
	- Verified that successfully created shards have identical virtual chunk layouts.