### PR TITLE
Adopt on_repl_devs_init_completed CB.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.16"
+    version = "2.1.17"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -92,7 +92,7 @@ void ReplicationStateMachine::on_rollback(int64_t lsn, sisl::blob const& header,
     }
 }
 
-void ReplicationStateMachine::on_restart() { home_object_->on_replica_restart(); }
+void ReplicationStateMachine::on_restart() { LOGD("ReplicationStateMachine::on_restart");}
 
 void ReplicationStateMachine::on_error(ReplServiceError error, const sisl::blob& header, const sisl::blob& key,
                                        cintrusive< repl_req_ctx >& ctx) {


### PR DESCRIPTION
moving PG/Shard recovery into this CB, through
HomeObject::on_replica_restart().

Stop calling on_replica_restart from StateMachine::on_restart().