### PR TITLE
PG cleanup for moved out member

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.17"
+    version = "2.1.18"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -79,6 +79,20 @@ public:
     // It is used in two scenarios: 1. seal shard  2. create shard rollback
     bool release_chunk(const pg_id_t pg_id, const chunk_num_t v_chunk_id);
 
+    bool reset_pg_chunks(pg_id_t pg_id);
+
+    /**
+     * Releases all chunks associated with the specified pg_id.
+     *
+     * This function is used to return all chunks that are currently associated with a particular
+     * pg identified by the given pg_id. It is typically used in scenarios where
+     * all chunks associated with a pg need to be freed, such as pg move out.
+     *
+     * @param pg_id The ID of the protection group whose chunks are to be released.
+     * @return A boolean value indicating whether the operation was successful.
+     */
+    bool return_pg_chunks_to_dev_heap(pg_id_t pg_id);
+
     /**
      * select chunks for pg, chunks need to be in same pdev.
      *

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -30,6 +30,7 @@ static constexpr uint64_t io_align{512};
 PGError toPgError(homestore::ReplServiceError const&);
 BlobError toBlobError(homestore::ReplServiceError const&);
 ShardError toShardError(homestore::ReplServiceError const&);
+ENUM(PGState, uint8_t, ALIVE = 0, DESTROYED);
 
 class HSHomeObject : public HomeObjectImpl {
 private:
@@ -80,6 +81,7 @@ public:
 
     struct pg_info_superblk {
         pg_id_t id;
+        PGState state;
         uint32_t num_members;
         uint32_t num_chunks;
         peer_id_t replica_set_uuid;
@@ -109,6 +111,7 @@ public:
 
         pg_info_superblk& operator=(pg_info_superblk const& rhs) {
             id = rhs.id;
+            state = rhs.state;
             num_members = rhs.num_members;
             num_chunks = rhs.num_chunks;
             pg_size = rhs.pg_size;
@@ -412,6 +415,20 @@ public:
                               const homestore::replica_member_info& member_in);
 
     /**
+     * @brief Cleans up and recycles resources for the PG identified by the given pg_id on the current node.
+     *
+     * This function is called when the replication device leaves or when a specific PG is destroyed on the current
+     * node. Note that this function does not perform Raft synchronization with other nodes.
+     *
+     * Possible scenarios for calling this function include:
+     * - A member-out node cleaning up resources for a specified PG.
+     * - During baseline rsync to clean up PG resources on the current node.
+     *
+     * @param pg_id The ID of the PG to be destroyed.
+     */
+    void pg_destroy(pg_id_t pg_id);
+
+    /**
      * @brief Callback function invoked when a message is committed on a shard.
      *
      * @param lsn The logical sequence number of the message.
@@ -488,6 +505,7 @@ public:
                                    size_t hash_len) const;
 
     std::shared_ptr< BlobIndexTable > recover_index_table(homestore::superblk< homestore::index_table_sb >&& sb);
+    std::optional< pg_id_t > get_pg_id_with_group_id(homestore::group_id_t group_id) const;
 
 private:
     std::shared_ptr< BlobIndexTable > create_index_table();
@@ -512,6 +530,36 @@ private:
     sisl::io_blob_safe& get_pad_buf(uint32_t pad_len);
 
     // void trigger_timed_events();
+
+    /**
+     * @brief Marks the PG as destroyed.
+     *
+     * Updates the internal state to indicate that the specified PG is destroyed and ensures its state is persisted.
+     *
+     * @param pg_id The ID of the PG to be marked as destroyed.
+     */
+    void mark_pg_destroyed(pg_id_t pg_id);
+
+    /**
+     * @brief Cleans up and recycles resources for shards in the PG located using a PG ID.
+     *
+     * @param pg_id The ID of the PG whose shards are to be destroyed.
+     */
+    void destroy_shards(pg_id_t pg_id);
+
+    /**
+     * @brief Resets the chunks for the given PG ID and triggers a checkpoint flush.
+     *
+     * @param pg_id The ID of the PG whose chunks are to be reset.
+     */
+    void reset_pg_chunks(pg_id_t pg_id);
+
+    /**
+     * @brief Cleans up and recycles resources for the PG located using a pg_id.
+     *
+     * @param pg_id The ID of the PG to be cleaned.
+     */
+    void cleanup_pg_resources(pg_id_t pg_id);
 };
 
 class BlobIndexServiceCallbacks : public homestore::IndexServiceCallbacks {

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -250,6 +250,79 @@ void HSHomeObject::on_pg_replace_member(homestore::group_id_t group_id, const re
          boost::uuids::to_string(member_in.id));
 }
 
+std::optional< pg_id_t > HSHomeObject::get_pg_id_with_group_id(homestore::group_id_t group_id) const {
+    auto lg = std::shared_lock(_pg_lock);
+    auto iter = std::find_if(_pg_map.begin(), _pg_map.end(), [group_id](const auto& entry) {
+        return pg_repl_dev(*entry.second).group_id() == group_id;
+    });
+    if (iter != _pg_map.end()) {
+        return iter->first;
+    } else {
+        return std::nullopt;
+    }
+}
+
+void HSHomeObject::pg_destroy(pg_id_t pg_id) {
+    mark_pg_destroyed(pg_id);
+    destroy_shards(pg_id);
+    reset_pg_chunks(pg_id);
+    cleanup_pg_resources(pg_id);
+    LOGI("pg {} is destroyed", pg_id);
+}
+void HSHomeObject::mark_pg_destroyed(pg_id_t pg_id) {
+    auto lg = std::scoped_lock(_pg_lock);
+    auto iter = _pg_map.find(pg_id);
+    if (iter == _pg_map.end()) {
+        LOGW("on pg destroy with unknown pg_id {}", pg_id);
+        return;
+    }
+    auto& pg = iter->second;
+    auto hs_pg = s_cast< HS_PG* >(pg.get());
+    hs_pg->pg_sb_->state = PGState::DESTROYED;
+    hs_pg->pg_sb_.write();
+}
+
+void HSHomeObject::reset_pg_chunks(pg_id_t pg_id) {
+    bool res = chunk_selector_->reset_pg_chunks(pg_id);
+    RELEASE_ASSERT(res, "Failed to reset all chunks in pg {}", pg_id);
+    auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(true /* force */);
+    auto on_complete = [&](auto success) {
+        RELEASE_ASSERT(success, "Failed to trigger CP flush");
+        LOGI("CP Flush completed");
+    };
+    on_complete(std::move(fut).get());
+}
+
+void HSHomeObject::cleanup_pg_resources(pg_id_t pg_id) {
+    auto lg = std::scoped_lock(_pg_lock);
+    auto iter = _pg_map.find(pg_id);
+    if (iter == _pg_map.end()) {
+        LOGW("on pg resource release with unknown pg_id {}", pg_id);
+        return;
+    }
+
+    // destroy index table
+    auto& pg = iter->second;
+    auto hs_pg = s_cast< HS_PG* >(pg.get());
+    if (nullptr != hs_pg->index_table_) {
+        auto uuid_str = boost::uuids::to_string(hs_pg->index_table_->uuid());
+        index_table_pg_map_.erase(uuid_str);
+        hs()->index_service().remove_index_table(hs_pg->index_table_);
+        hs_pg->index_table_->destroy();
+    }
+
+    // destroy pg super blk
+    hs_pg->pg_sb_.destroy();
+
+    // return pg chunks to dev heap
+    // which must be done after destroying pg super blk to avoid multiple pg use same chunks
+    bool res = chunk_selector_->return_pg_chunks_to_dev_heap(pg_id);
+    RELEASE_ASSERT(res, "Failed to return pg {} chunks to dev_heap", pg_id);
+
+    // erase pg in pg map
+    _pg_map.erase(iter);
+}
+
 void HSHomeObject::add_pg_to_map(unique< HS_PG > hs_pg) {
     RELEASE_ASSERT(hs_pg->pg_info_.replica_set_uuid == hs_pg->repl_dev_->group_id(),
                    "PGInfo replica set uuid mismatch with ReplDev instance for {}",
@@ -317,9 +390,14 @@ void HSHomeObject::on_pg_meta_blk_found(sisl::byte_view const& buf, void* meta_c
     // add entry in map, so that index recovery can update the PG.
     std::scoped_lock lg(index_lock_);
     auto it = index_table_pg_map_.find(uuid_str);
-    RELEASE_ASSERT(it != index_table_pg_map_.end(), "IndexTable should be recovered before PG");
-    hs_pg->index_table_ = it->second.index_table;
-    it->second.pg_id = pg_id;
+    if (it != index_table_pg_map_.end()) {
+        hs_pg->index_table_ = it->second.index_table;
+        it->second.pg_id = pg_id;
+    } else {
+        RELEASE_ASSERT(hs_pg->pg_sb_->state == PGState::DESTROYED, "IndexTable should be recovered before PG");
+        hs_pg->index_table_ = nullptr;
+        LOGI("Index table not found for destroyed pg_id={}, index_table_uuid={}", pg_id, uuid_str);
+    }
 
     add_pg_to_map(std::move(hs_pg));
 }
@@ -349,6 +427,7 @@ HSHomeObject::HS_PG::HS_PG(PGInfo info, shared< homestore::ReplDev > rdev, share
     pg_sb_.create(sizeof(pg_info_superblk) - sizeof(char) + pg_info_.members.size() * sizeof(pg_members) +
                   num_chunks * sizeof(homestore::chunk_num_t));
     pg_sb_->id = pg_info_.id;
+    pg_sb_->state = PGState::ALIVE;
     pg_sb_->num_members = pg_info_.members.size();
     pg_sb_->num_chunks = num_chunks;
     pg_sb_->pg_size = pg_info_.size;

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -193,8 +193,14 @@ void ReplicationStateMachine::on_replace_member(const homestore::replica_member_
 }
 
 void ReplicationStateMachine::on_destroy(const homestore::group_id_t& group_id) {
-    // TODO:: add the logic to handle destroy
-    LOGI("replica destroyed");
+    auto PG_ID = home_object_->get_pg_id_with_group_id(group_id);
+    if (!PG_ID.has_value()) {
+        LOGW("do not have pg mapped by group_id {}", boost::uuids::to_string(group_id));
+        return;
+    }
+    home_object_->pg_destroy(PG_ID.value());
+    LOGI("replica destroyed, cleared PG {} resources with group_id {}", PG_ID.value(),
+         boost::uuids::to_string(group_id));
 }
 
 homestore::AsyncReplResult<>

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -14,6 +14,9 @@ TEST_F(HomeObjectFixture, BasicEquivalence) {
 }
 
 TEST_F(HomeObjectFixture, BasicPutGetDelBlobWRestart) {
+    // test recovery with pristine state firstly
+    restart();
+
     auto num_pgs = SISL_OPTIONS["num_pgs"].as< uint64_t >();
     auto num_shards_per_pg = SISL_OPTIONS["num_shards"].as< uint64_t >() / num_pgs;
 

--- a/src/lib/homestore_backend/tests/hs_pg_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_pg_tests.cpp
@@ -124,6 +124,11 @@ TEST_F(HomeObjectFixture, PGSizeLessThanChunkTest) {
 }
 
 TEST_F(HomeObjectFixture, PGRecoveryTest) {
+    auto id = _obj_inst->our_uuid();
+    // test recovery with pristine state firstly
+    restart();
+    EXPECT_EQ(id, _obj_inst->our_uuid());
+
     // create 10 pg
     for (pg_id_t i = 1; i < 11; i++) {
         pg_id_t pg_id{i};
@@ -131,12 +136,8 @@ TEST_F(HomeObjectFixture, PGRecoveryTest) {
     }
 
     // get pg map
-    HSHomeObject* ho = dynamic_cast< HSHomeObject* >(_obj_inst.get());
     std::map< pg_id_t, std::unique_ptr< PG > > pg_map;
-    pg_map.swap(ho->_pg_map);
-
-    // get uuid
-    auto id = ho->our_uuid();
+    pg_map.swap(_obj_inst->_pg_map);
 
     // restart
     restart();

--- a/src/lib/homestore_backend/tests/hs_shard_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_shard_tests.cpp
@@ -171,6 +171,9 @@ TEST_F(HomeObjectFixture, ShardManagerRecovery) {
 }
 
 TEST_F(HomeObjectFixture, SealedShardRecovery) {
+    // test recovery with pristine state firstly
+    restart();
+
     pg_id_t pg_id{1};
     create_pg(pg_id);
 

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -73,7 +73,7 @@ uint16_t VChunk::get_chunk_id() const { return m_internal_chunk->get_chunk_id();
 blk_num_t VChunk::get_total_blks() const { return m_internal_chunk->get_total_blks(); }
 
 uint64_t VChunk::size() const { return m_internal_chunk->size(); }
-
+void VChunk::reset() {}
 cshared< Chunk > VChunk::get_internal_chunk() const { return m_internal_chunk; }
 
 } // namespace homestore
@@ -273,6 +273,18 @@ TEST_F(HeapChunkSelectorTest, test_select_specific_chunk_and_release_chunk) {
         ASSERT_EQ(pg_chunk_collection->available_blk_count, 1 + 2);
         ASSERT_EQ(pg_id, chunk->get_pdev_id()); // in this ut, pg_id is same as pdev id
         ASSERT_EQ(p_chunk_id, chunk->get_chunk_id());
+    }
+}
+
+TEST_F(HeapChunkSelectorTest, test_return_pg_chunks) {
+    for (uint16_t pg_id = 1; pg_id < 4; ++pg_id) {
+        ASSERT_TRUE(HCS.return_pg_chunks_to_dev_heap(pg_id));
+        ASSERT_EQ(HCS.m_per_pg_chunks.find(pg_id), HCS.m_per_pg_chunks.end());
+        ASSERT_EQ(HCS.m_per_dev_heap[pg_id]->available_blk_count, 1 + 2 + 3);
+        ASSERT_EQ(HCS.m_per_dev_heap[pg_id]->available_blk_count, HCS.m_per_dev_heap[pg_id]->m_total_blks);
+    }
+    for (const auto& [_, chunk] : HCS.m_chunks) {
+        ASSERT_EQ(chunk->m_state, ChunkState::AVAILABLE);
     }
 }
 


### PR DESCRIPTION
When a member is moved out of a PG, clean up the PG and reclaim resources:

1. Reset all chunk allocators and return chunks for reassignment.
2. Remove the index table associated with this PG.
3. Remove this PG from the PG map.
4. Delete the PG and its related shard metadata.

Additionally, enhance restart tests with pristine state validation, covering PG, shard, and blob tests.