### PR TITLE
Add more UT for error cases simulated with sisl::flip

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.19"
+    version = "2.1.20"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -49,7 +49,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[^6.5.19]@oss/master")
+        self.requires("homestore/[^6.6]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/3.3.1", override=True)

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -69,5 +69,12 @@ target_link_libraries(homestore_test_dynamic PUBLIC
     ${COMMON_TEST_DEPS}
 )
 
-add_test(NAME HomestoreTestDynamic COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./ --override_config homestore_config.consensus.snapshot_freq_distance:0)
+add_test(NAME HomestoreTestDynamic
+        COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
+        --override_config homestore_config.consensus.snapshot_freq_distance:0)
 
+# To test both baseline & incremental resync functionality, we use 13 to minimize the likelihood of it being a divisor of the total LSN (currently 30)
+add_test(NAME HomestoreTestDynamicWithResync
+        COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
+        --override_config homestore_config.consensus.snapshot_freq_distance:13
+        --override_config homestore_config.consensus.num_reserved_log_items=13)

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -177,6 +177,8 @@ public:
      */
     uint32_t total_disks() const { return m_per_dev_heap.size(); }
 
+    bool is_chunk_available(const pg_id_t pg_id, const chunk_num_t v_chunk_id) const;
+
 private:
     void add_chunk_internal(const chunk_num_t, bool add_to_heap = true);
 

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -41,9 +41,9 @@ PGError toPgError(ReplServiceError const& e) {
     case ReplServiceError::RETRY_REQUEST:
         return PGError::RETRY_REQUEST;
     /* TODO: enable this after add erro type to homestore
-    case ReplServiceError::CRC_MISMATCH:
-        return PGError::CRC_MISMATCH;
-     */
+            case ReplServiceError::CRC_MISMATCH:
+                return PGError::CRC_MISMATCH;
+             */
     case ReplServiceError::OK:
         DEBUG_ASSERT(false, "Should not process OK!");
         [[fallthrough]];

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -84,6 +84,12 @@ PG* HSHomeObject::PGBlobIterator::get_pg_metadata() {
 }
 
 bool HSHomeObject::PGBlobIterator::create_pg_snapshot_data(sisl::io_blob_safe& meta_blob) {
+#ifdef _PRERELEASE
+    if (iomgr_flip::instance()->test_flip("pg_blob_iterator_create_snapshot_data_error")) {
+        LOGW("Simulating creating pg snapshot data error");
+        return false;
+    }
+#endif
     auto pg = home_obj_._pg_map[pg_id_].get();
     if (pg == nullptr) {
         LOGE("PG not found in pg_map, pg_id={}", pg_id_);
@@ -112,6 +118,12 @@ bool HSHomeObject::PGBlobIterator::create_pg_snapshot_data(sisl::io_blob_safe& m
 }
 
 bool HSHomeObject::PGBlobIterator::generate_shard_blob_list() {
+#ifdef _PRERELEASE
+    if (iomgr_flip::instance()->test_flip("pg_blob_iterator_generate_shard_blob_list_error")) {
+        LOGW("Simulating generating shard blob list error");
+        return false;
+    }
+#endif
     auto r = home_obj_.query_blobs_in_shard(pg_id_, cur_obj_id_.shard_seq_num, 0, UINT64_MAX);
     if (!r) { return false; }
     cur_blob_list_ = r.value();
@@ -211,6 +223,12 @@ bool HSHomeObject::PGBlobIterator::create_blobs_snapshot_data(sisl::io_blob_safe
             continue;
         }
 
+#ifdef _PRERELEASE
+        if (iomgr_flip::instance()->test_flip("pg_blob_iterator_load_blob_data_error")) {
+            LOGW("Simulating loading blob data error");
+            return false;
+        }
+#endif
         sisl::io_blob_safe blob;
         uint8_t retries = HS_BACKEND_DYNAMIC_CONFIG(snapshot_blob_load_retry);
         for (int i = 0; i < retries; i++) {

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -474,9 +474,37 @@ private:
         return blob;
     }
 
+#ifdef _PRERELEASE
+    void set_basic_flip(const std::string flip_name, uint32_t count = 1, uint32_t percent = 100) {
+        flip::FlipCondition null_cond;
+        flip::FlipFrequency freq;
+        freq.set_count(count);
+        freq.set_percent(percent);
+        m_fc.inject_noreturn_flip(flip_name, {null_cond}, freq);
+        LOGINFO("Flip {} set", flip_name);
+    }
+
+    void set_delay_flip(const std::string flip_name, uint64_t delay_usec, uint32_t count = 1, uint32_t percent = 100) {
+        flip::FlipCondition null_cond;
+        flip::FlipFrequency freq;
+        freq.set_count(count);
+        freq.set_percent(percent);
+        m_fc.inject_delay_flip(flip_name, {null_cond}, freq, delay_usec);
+        LOGINFO("Flip {} set", flip_name);
+    }
+
+    void remove_flip(const std::string flip_name) {
+        m_fc.remove_flip(flip_name);
+        LOGINFO("Flip {} removed", flip_name);
+    }
+#endif
+
 private:
     std::random_device rnd{};
     std::default_random_engine rnd_engine{rnd()};
     std::uniform_int_distribution< uint32_t > rand_blob_size;
     std::uniform_int_distribution< uint32_t > rand_user_key_size;
+#ifdef _PRERELEASE
+    flip::FlipClient m_fc{iomgr_flip::instance()};
+#endif
 };

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -293,14 +293,14 @@ TEST_F(HomeObjectFixture, PGBlobIterator) {
 }
 
 TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
-    // TODO: add filps to test corrupted data
     // MUST TEST WITH replica=1
     constexpr uint64_t snp_lsn = 1;
     constexpr uint64_t num_shards_per_pg = 3;
     constexpr uint64_t num_open_shards_per_pg = 2; // Should be less than num_shards_per_pg
-    constexpr uint64_t num_batches_per_shard = 3;
+    constexpr uint64_t num_batches_per_shard = 5;
     constexpr uint64_t num_blobs_per_batch = 5;
-    constexpr int corrupted_blob_percentage = 10;
+    constexpr int corrupted_blob_percentage = 10;             // Percentage of blobs with state = CORRUPTED
+    constexpr int unexpected_corrupted_batch_percentage = 15; // Percentage of batches with unexpected data corruption
 
     // We have to create a PG first to init repl_dev
     constexpr pg_id_t pg_id = 1;
@@ -353,8 +353,9 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
         // Generate ResyncShardMetaData message
         ShardInfo shard;
         shard.id = i;
-        shard.state =
-            i <= num_shards_per_pg - num_open_shards_per_pg ? ShardInfo::State::SEALED : ShardInfo::State::OPEN;
+        shard.state = i <= num_shards_per_pg - num_open_shards_per_pg
+            ? ShardInfo::State::SEALED
+            : ShardInfo::State::OPEN; // Open shards arrive at last
         shard.created_time = get_time_since_epoch_ms();
         shard.last_modified_time = shard.created_time;
         shard.total_capacity_bytes = 1024 * Mi;
@@ -370,6 +371,9 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
         auto ret = handler->process_shard_snapshot_data(*shard_meta);
         builder.Reset();
         ASSERT_EQ(ret, 0);
+        ASSERT_EQ(handler->get_shard_cursor(), shard.id);
+        ASSERT_EQ(handler->get_next_shard(),
+                  i == num_shards_per_pg ? HSHomeObject::SnapshotReceiveHandler::shard_list_end_marker : i + 1);
 
         auto res = _obj_inst->shard_manager()->get_shard(shard.id).get();
         ASSERT_TRUE(!!res);
@@ -385,8 +389,10 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
         // Generate ResyncBlobDataBatch message
         std::map< blob_id_t, std::tuple< Blob, bool > > blob_map;
         for (uint64_t j = 1; j <= num_batches_per_shard; j++) {
-            LOGINFO("TESTING: applying blobs for shard {} batch {}", shard.id, j);
-            std::vector< ::flatbuffers::Offset< ResyncBlobData > > blob_entries;
+            bool is_corrupted_batch = j < num_batches_per_shard &&
+                corrupt_dis(gen) <= unexpected_corrupted_batch_percentage; // Don't test on last batch
+            LOGINFO("TESTING: applying blobs for shard {} batch {}, is_corrupted {}", shard.id, j, is_corrupted_batch);
+            std::vector< flatbuffers::Offset< ResyncBlobData > > blob_entries;
             for (uint64_t k = 0; k < num_blobs_per_batch; k++) {
                 auto blob_state = corrupt_dis(gen) <= corrupted_blob_percentage ? ResyncBlobState::CORRUPTED
                                                                                 : ResyncBlobState::NORMAL;
@@ -418,7 +424,8 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
                 std::memcpy(blob_raw.bytes() + aligned_hdr_size, blob.body.cbytes(), blob.body.size());
 
                 // Simulate blob data corruption - tamper with random bytes
-                if (blob_state == ResyncBlobState::CORRUPTED) {
+                if (is_corrupted_batch || blob_state == ResyncBlobState::CORRUPTED) {
+                    LOGINFO("Simulating corrupted blob data for shard {} blob {}", shard.id, cur_blob_id);
                     constexpr int corrupted_bytes = 5;
                     for (auto i = 0; i < corrupted_bytes; i++) {
                         auto offset = random_bytes_dis(gen) % blob_raw.size();
@@ -431,15 +438,27 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
                 std::vector data(blob_raw.bytes(), blob_raw.bytes() + blob_raw.size());
                 blob_entries.push_back(
                     CreateResyncBlobDataDirect(builder, cur_blob_id, static_cast< uint8_t >(blob_state), &data));
-                blob_map[cur_blob_id++] =
-                    std::make_tuple< Blob, bool >(std::move(blob), blob_state == ResyncBlobState::CORRUPTED);
+                if (!is_corrupted_batch) {
+                    blob_map[cur_blob_id] =
+                        std::make_tuple< Blob, bool >(std::move(blob), blob_state == ResyncBlobState::CORRUPTED);
+                }
+                cur_blob_id++;
             }
             builder.Finish(CreateResyncBlobDataBatchDirect(builder, &blob_entries, true));
             auto blob_batch = GetResyncBlobDataBatch(builder.GetBufferPointer());
             ret = handler->process_blobs_snapshot_data(*blob_batch, j, j == num_batches_per_shard);
+            if (is_corrupted_batch) {
+                ASSERT_NE(ret, 0);
+            } else {
+                ASSERT_EQ(ret, 0);
+            }
             builder.Reset();
-            ASSERT_EQ(ret, 0);
+            ASSERT_EQ(handler->get_shard_cursor(), shard.id);
+            ASSERT_EQ(handler->get_next_shard(),
+                      i == num_shards_per_pg ? HSHomeObject::SnapshotReceiveHandler::shard_list_end_marker : i + 1);
         }
+
+        // Verify blobs
         for (const auto& b : blob_map) {
             auto blob_id = b.first;
             auto& blob = std::get< 0 >(b.second);
@@ -455,8 +474,13 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
                 ASSERT_EQ(std::memcmp(blob_res.body.bytes(), blob.body.cbytes(), blob_res.body.size()), 0);
             }
         }
+
+        // Verify chunk of sealed shards are successfully released
         if (shard.state == ShardInfo::State::SEALED) {
-            // TODO: Verify chunk is released. Currently we don't have chunk_id, so let's do this after rebasing
+            auto v = _obj_inst->get_shard_v_chunk_id(shard.id);
+            ASSERT_TRUE(v.has_value());
+            ASSERT_EQ(v.value(), v_chunk_id.value());
+            ASSERT_TRUE(_obj_inst->chunk_selector()->is_chunk_available(pg_id, v.value()));
         }
     }
 }

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -293,7 +293,6 @@ TEST_F(HomeObjectFixture, PGBlobIterator) {
 }
 
 TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
-    // MUST TEST WITH replica=1
     constexpr uint64_t snp_lsn = 1;
     constexpr uint64_t num_shards_per_pg = 3;
     constexpr uint64_t num_open_shards_per_pg = 2; // Should be less than num_shards_per_pg
@@ -389,8 +388,9 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
         // Generate ResyncBlobDataBatch message
         std::map< blob_id_t, std::tuple< Blob, bool > > blob_map;
         for (uint64_t j = 1; j <= num_batches_per_shard; j++) {
-            bool is_corrupted_batch = j < num_batches_per_shard &&
-                corrupt_dis(gen) <= unexpected_corrupted_batch_percentage; // Don't test on last batch
+            // Don't test unexpected corruption on the last batch, since for simplicity we're not simulating resending
+            bool is_corrupted_batch =
+                j < num_batches_per_shard && corrupt_dis(gen) <= unexpected_corrupted_batch_percentage;
             LOGINFO("TESTING: applying blobs for shard {} batch {}, is_corrupted {}", shard.id, j, is_corrupted_batch);
             std::vector< flatbuffers::Offset< ResyncBlobData > > blob_entries;
             for (uint64_t k = 0; k < num_blobs_per_batch; k++) {


### PR DESCRIPTION
Enhance existing class-level UT:
* Add test for handling corrupted message
* Add verification for chunk release of sealed shards

Introduce `sisl::flip` and simulate error cases in dynamic test