### PR TITLE
Baseline Resync Enhancement

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.1.20"
+    version = "2.1.21"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/index_kv.cpp
+++ b/src/lib/homestore_backend/index_kv.cpp
@@ -40,6 +40,7 @@ HSHomeObject::recover_index_table(homestore::superblk< homestore::index_table_sb
     return index_table;
 }
 
+//The bool result indicates if the blob already exists, but if the existing pbas is the same as the new pbas, it will return homestore::btree_status_t::success.
 std::pair< bool, homestore::btree_status_t > HSHomeObject::add_to_index_table(shared< BlobIndexTable > index_table,
                                                                               const BlobInfo& blob_info) {
     BlobRouteKey index_key{BlobRoute{blob_info.shard_id, blob_info.blob_id}};
@@ -48,8 +49,17 @@ std::pair< bool, homestore::btree_status_t > HSHomeObject::add_to_index_table(sh
                                              &existing_value};
     auto status = index_table->put(put_req);
     if (status != homestore::btree_status_t::success) {
+        if (existing_value.pbas().is_valid() && existing_value.pbas() == blob_info.pbas) {
+            LOGT(
+                "blob already exists, but existing pbas is the same as the new pbas, ignore it, blob_id={}, pbas={}, status={}",
+                blob_info.blob_id, blob_info.pbas.to_string(), status);
+            return {true, homestore::btree_status_t::success};
+        }
         if (existing_value.pbas().is_valid() || existing_value.pbas() == tombstone_pbas) {
             // Check if the blob id already exists in the index or its tombstone.
+            LOGW(
+                "blob already exists, and conflict occurs, blob_id={}, existing pbas={}, new pbas={}, status={}",
+                blob_info.blob_id, existing_value.pbas().to_string(), blob_info.pbas.to_string(), status);
             return {true, status};
         }
         LOGE("Failed to put to index table error {}", status);

--- a/src/lib/homestore_backend/replication_message.hpp
+++ b/src/lib/homestore_backend/replication_message.hpp
@@ -67,6 +67,7 @@ struct ReplicationMessageHeader : public BaseMessageHeader<ReplicationMessageHea
     pg_id_t pg_id{0};
     uint8_t reserved_pad[4]{};
     shard_id_t shard_id{0};
+    blob_id_t blob_id{0};
 
     bool corrupted() const{
         if (magic_num != HOMEOBJECT_REPLICATION_MAGIC || protocol_version != HOMEOBJECT_REPLICATION_PROTOCOL_VERSION_V1) {

--- a/src/lib/homestore_backend/snapshot_receive_handler.cpp
+++ b/src/lib/homestore_backend/snapshot_receive_handler.cpp
@@ -212,15 +212,15 @@ int HSHomeObject::SnapshotReceiveHandler::process_blobs_snapshot_data(ResyncBlob
                              .thenValue([&blk_id](auto&& err) -> BlobManager::AsyncResult< blob_id_t > {
                                  // TODO: do we need to update repl_dev metrics?
                                  if (err) {
-                                     LOGE("Failed to write shard info to blk_id: {}", blk_id.to_string());
+                                     LOGE("Failed to write blob info to blk_id: {}", blk_id.to_string());
                                      return folly::makeUnexpected(BlobError(BlobErrorCode::REPLICATION_ERROR));
                                  }
-                                 LOGD("Shard info written to blk_id:{}", blk_id.to_string());
+                                 LOGD("Blob info written to blk_id:{}", blk_id.to_string());
                                  return 0;
                              })
                              .get();
         if (ret.hasError()) {
-            LOGE("Failed to write shard info of blob_id {} to blk_id:{}", blob->blob_id(), blk_id.to_string());
+            LOGE("Failed to write blob info of blob_id {} to blk_id:{}", blob->blob_id(), blk_id.to_string());
             free_allocated_blks();
             return WRITE_DATA_ERR;
         }


### PR DESCRIPTION
This PR enhances baseline resync:
1. Address blob duplication issues caused by resync, it mainly happens when resend snapshot mesg during baseline resync and apply log after snapshot completion. This helps avoid unnecessary GC due to duplicated data. 
This mechanism is effective only for duplicated blobs. Since we do not record the blks of the `shardInfo` stored in the data service, we are unable to skip data writes for duplicated shards.
2. Reset PG and context at the beginning of the baseline resync if pg is already present.