### PR TITLE
Reclaim resources on PG creation failure and add concurrency support for PG creation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.0"
+    version = "2.2.1"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_shard_manager.cpp
+++ b/src/lib/homestore_backend/hs_shard_manager.cpp
@@ -553,7 +553,6 @@ void HSHomeObject::destroy_shards(pg_id_t pg_id) {
 
     auto& pg = iter->second;
     for (auto& shard : pg->shards_) {
-        // release open shard v_chunk
         auto hs_shard = s_cast< HS_Shard* >(shard.get());
         // destroy shard super blk
         hs_shard->sb_.destroy();

--- a/src/lib/homestore_backend/tests/hs_pg_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_pg_tests.cpp
@@ -1,4 +1,5 @@
 #include "homeobj_fixture.hpp"
+#include <homestore/replication_service.hpp>
 
 TEST_F(HomeObjectFixture, PGStatsTest) {
     LOGINFO("HomeObject replica={} setup completed", g_helper->replica_num());
@@ -157,3 +158,93 @@ TEST_F(HomeObjectFixture, PGRecoveryTest) {
         verify_hs_pg(reserved_pg, recovered_pg);
     }
 }
+
+TEST_F(HomeObjectFixture, ConcurrencyCreatePG) {
+    g_helper->sync();
+
+    LOGINFO("print num chunks {}", _obj_inst->chunk_selector()->m_chunks.size());
+    auto const pg_num = 10;
+    // concurrent create pg
+    std::vector< std::future< void > > futures;
+    for (pg_id_t i = 1; i <= pg_num; ++i) {
+        futures.emplace_back(std::async(std::launch::async, [this, i]() { create_pg(i); }));
+    }
+    for (auto& future : futures) {
+        future.get();
+    }
+
+    // verify all pgs are created
+    for (pg_id_t i = 1; i <= pg_num; ++i) {
+        ASSERT_TRUE(pg_exist(i));
+        LOGINFO("Create pg {} successfully", i);
+    }
+}
+
+#ifdef _PRERELEASE
+TEST_F(HomeObjectFixture, CreatePGFailed) {
+    set_basic_flip("create_pg_create_repl_dev_error", 1); // simulate create pg repl dev error
+    set_basic_flip("create_pg_raft_message_error", 1);    // simulate create pg raft message error
+
+    // test twice to trigger each simulate error
+    for (auto i = 0; i < 2; ++i) {
+        g_helper->sync();
+        auto const pg_id = 1;
+        const uint8_t leader_replica_num = 0;
+        auto my_replica_num = g_helper->replica_num();
+        auto pg_size = SISL_OPTIONS["pg_size"].as< uint64_t >() * Mi;
+        auto name = g_helper->test_name();
+        if (leader_replica_num == my_replica_num) {
+            auto members = g_helper->members();
+            auto info = homeobject::PGInfo(pg_id);
+            info.size = pg_size;
+            for (const auto& member : members) {
+                if (leader_replica_num == member.second) {
+                    // by default, leader is the first member
+                    info.members.insert(homeobject::PGMember{member.first, name + std::to_string(member.second), 1});
+                } else {
+                    info.members.insert(homeobject::PGMember{member.first, name + std::to_string(member.second), 0});
+                }
+            }
+            auto p = _obj_inst->pg_manager()->create_pg(std::move(info)).get();
+            ASSERT_FALSE(p);
+            ASSERT_EQ(PGError::UNKNOWN, p.error());
+
+            // verify pg resource
+            // since pg creation failed, the pg chunks should not exist
+            ASSERT_TRUE(_obj_inst->chunk_selector()->m_per_pg_chunks.find(pg_id) ==
+                        _obj_inst->chunk_selector()->m_per_pg_chunks.end());
+            // wait for repl gc.
+            std::this_thread::sleep_for(std::chrono::seconds(70));
+            int num_repl = 0;
+            _obj_inst->hs_repl_service().iterate_repl_devs([&num_repl](cshared< homestore::ReplDev >&) { num_repl++; });
+            LOGINFO("Failed to create pg {} at leader, times {}， num_repl {}", pg_id, i, num_repl);
+            ASSERT_EQ(0, num_repl);
+
+        } else {
+            auto start_time = std::chrono::steady_clock::now();
+            bool res = true;
+            // follower need to wait for pg creation
+            while (!pg_exist(pg_id)) {
+                auto current_time = std::chrono::steady_clock::now();
+                auto duration = std::chrono::duration_cast< std::chrono::seconds >(current_time - start_time).count();
+                if (duration >= 20) {
+                    LOGINFO("Failed to create pg {} at follower", pg_id);
+                    res = false;
+                    break;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+            }
+            ASSERT_FALSE(res);
+        }
+    }
+
+    // test create pg successfully
+    g_helper->sync();
+    auto const pg_id = 1;
+    create_pg(pg_id);
+    ASSERT_TRUE(pg_exist(pg_id));
+    LOGINFO("create pg {} successfully", pg_id);
+    restart();
+    ASSERT_TRUE(pg_exist(pg_id));
+}
+#endif


### PR DESCRIPTION

- Reclaim resources if PG creation fails:
  - Ensure chunks are returned to the device heap if PG creation fails.
  - Remove replication device if PG creation fails.
  - Add flip test.

- Add concurrency support for receiving PG creation requests:
  - Use `select_chunks_for_pg()` to support concurrent requests instead of only checking size.
  - Add concurrency tests to verify the behavior of concurrent PG creation requests.