### PR TITLE
Recover chunk_size in pg_info after restart

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.0"
+    version = "2.2.1"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -87,6 +87,7 @@ public:
         PGState state;
         uint32_t num_members;
         uint32_t num_chunks;
+        uint64_t chunk_size;
         peer_id_t replica_set_uuid;
         uint64_t pg_size;
         homestore::uuid_t index_table_uuid;

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -430,6 +430,7 @@ PGInfo HSHomeObject::HS_PG::pg_info_from_sb(homestore::superblk< pg_info_superbl
     }
     pginfo.size = sb->pg_size;
     pginfo.replica_set_uuid = sb->replica_set_uuid;
+    pginfo.chunk_size = sb->chunk_size;
     return pginfo;
 }
 
@@ -448,6 +449,7 @@ HSHomeObject::HS_PG::HS_PG(PGInfo info, shared< homestore::ReplDev > rdev, share
     pg_sb_->state = PGState::ALIVE;
     pg_sb_->num_members = pg_info_.members.size();
     pg_sb_->num_chunks = num_chunks;
+    pg_sb_->chunk_size = pg_info_.chunk_size;
     pg_sb_->pg_size = pg_info_.size;
     pg_sb_->replica_set_uuid = repl_dev_->group_id();
     pg_sb_->index_table_uuid = index_table_->uuid();

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -363,6 +363,7 @@ public:
         EXPECT_EQ(lhs->id, rhs->id);
         EXPECT_EQ(lhs->num_members, rhs->num_members);
         EXPECT_EQ(lhs->num_chunks, rhs->num_chunks);
+        EXPECT_EQ(lhs->chunk_size, rhs->chunk_size);
         EXPECT_EQ(lhs->pg_size, rhs->pg_size);
         EXPECT_EQ(lhs->replica_set_uuid, rhs->replica_set_uuid);
         EXPECT_EQ(lhs->index_table_uuid, rhs->index_table_uuid);
@@ -379,6 +380,12 @@ public:
         for (homestore::chunk_num_t i = 0; i < lhs->num_chunks; ++i) {
             EXPECT_EQ(lhs->get_chunk_ids()[i], rhs->get_chunk_ids()[i]);
         }
+
+        //verify recovered pg_info
+        EXPECT_EQ(lhs_pg->pg_info_.id, rhs_pg->pg_info_.id);
+        EXPECT_EQ(lhs_pg->pg_info_.replica_set_uuid, rhs_pg->pg_info_.replica_set_uuid);
+        EXPECT_EQ(lhs_pg->pg_info_.size, rhs_pg->pg_info_.size);
+        EXPECT_EQ(lhs_pg->pg_info_.chunk_size, rhs_pg->pg_info_.chunk_size);
     }
 
     void verify_hs_shard(const ShardInfo& lhs, const ShardInfo& rhs) {


### PR DESCRIPTION
chunk_size is not persisted in pg_sb, so set it manually during recovery.
Fix [issue24](https://docs.google.com/document/d/16DMqv9J-JuNs5c25IBuX01QXe5WbxPm4B4hAfz4JNZM/edit?tab=t.0#heading=h.pwx5p8lqreyh).