### PR TITLE
Implementation of follower-side snapshot transmission resumption

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.4"
+    version = "2.2.5"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -77,4 +77,5 @@ add_test(NAME HomestoreTestDynamic
 add_test(NAME HomestoreTestDynamicWithResync
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
         --override_config homestore_config.consensus.snapshot_freq_distance:13
-        --override_config homestore_config.consensus.num_reserved_log_items=13)
+        --override_config homestore_config.consensus.num_reserved_log_items=13
+        --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000)

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -75,6 +75,6 @@ add_test(NAME HomestoreTestDynamic
 
 # To test both baseline & incremental resync functionality, we use 13 to minimize the likelihood of it being a divisor of the total LSN (currently 30)
 add_test(NAME HomestoreTestDynamicWithResync
-        COMMAND homestore_test_dynamic --gtest_filter="HomeObjectFixture.ReplaceMember" -csv error --executor immediate --config_path ./
+        COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
         --override_config homestore_config.consensus.snapshot_freq_distance:13
         --override_config homestore_config.consensus.num_reserved_log_items=13)

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -251,6 +251,14 @@ void HSHomeObject::on_replica_restart() {
             [this](meta_blk* mblk, sisl::byte_view buf, size_t size) { on_snp_rcvr_meta_blk_found(mblk, buf); },
             [this](bool success) { on_snp_rcvr_meta_blk_recover_completed(success); }, true);
         HomeStore::instance()->meta_service().read_sub_sb(_snp_rcvr_meta_name);
+
+        HomeStore::instance()->meta_service().register_handler(
+            _snp_rcvr_shard_list_meta_name,
+            [this](meta_blk* mblk, sisl::byte_view buf, size_t size) {
+                on_snp_rcvr_shard_list_meta_blk_found(mblk, buf);
+            },
+            [this](bool success) { on_snp_rcvr_shard_list_meta_blk_recover_completed(success); }, true);
+        HomeStore::instance()->meta_service().read_sub_sb(_snp_rcvr_shard_list_meta_name);
     });
 }
 

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -244,6 +244,13 @@ void HSHomeObject::on_replica_restart() {
             [this](homestore::meta_blk* mblk, sisl::byte_view buf, size_t size) { on_shard_meta_blk_found(mblk, buf); },
             [this](bool success) { on_shard_meta_blk_recover_completed(success); }, true);
         HomeStore::instance()->meta_service().read_sub_sb(_shard_meta_name);
+
+        // recover snapshot transmission progress info
+        HomeStore::instance()->meta_service().register_handler(
+            _snp_rcvr_meta_name,
+            [this](meta_blk* mblk, sisl::byte_view buf, size_t size) { on_snp_rcvr_meta_blk_found(mblk, buf); },
+            [this](bool success) { on_snp_rcvr_meta_blk_recover_completed(success); }, true);
+        HomeStore::instance()->meta_service().read_sub_sb(_snp_rcvr_meta_name);
     });
 }
 

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -508,7 +508,8 @@ HSHomeObject::HS_PG::HS_PG(PGInfo info, shared< homestore::ReplDev > rdev, share
         repl_dev_{std::move(rdev)},
         index_table_{std::move(index_table)},
         metrics_{*this},
-        snp_rcvr_info_sb_{_snp_rcvr_meta_name} {
+        snp_rcvr_info_sb_{_snp_rcvr_meta_name},
+        snp_rcvr_shard_list_sb_{_snp_rcvr_shard_list_meta_name} {
     RELEASE_ASSERT(pg_chunk_ids != nullptr, "PG chunks null");
     const uint32_t num_chunks = pg_chunk_ids->size();
     pg_sb_.create(sizeof(pg_info_superblk) - sizeof(char) + pg_info_.members.size() * sizeof(pg_members) +

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -507,7 +507,8 @@ HSHomeObject::HS_PG::HS_PG(PGInfo info, shared< homestore::ReplDev > rdev, share
         pg_sb_{_pg_meta_name},
         repl_dev_{std::move(rdev)},
         index_table_{std::move(index_table)},
-        metrics_{*this} {
+        metrics_{*this},
+        snp_rcvr_info_sb_{_snp_rcvr_meta_name} {
     RELEASE_ASSERT(pg_chunk_ids != nullptr, "PG chunks null");
     const uint32_t num_chunks = pg_chunk_ids->size();
     pg_sb_.create(sizeof(pg_info_superblk) - sizeof(char) + pg_info_.members.size() * sizeof(pg_members) +
@@ -538,8 +539,7 @@ HSHomeObject::HS_PG::HS_PG(PGInfo info, shared< homestore::ReplDev > rdev, share
     pg_sb_.write();
 }
 
-HSHomeObject::HS_PG::HS_PG(homestore::superblk< HSHomeObject::pg_info_superblk >&& sb,
-                           shared< homestore::ReplDev > rdev) :
+HSHomeObject::HS_PG::HS_PG(superblk< pg_info_superblk >&& sb, shared< ReplDev > rdev) :
         PG{pg_info_from_sb(sb)}, pg_sb_{std::move(sb)}, repl_dev_{std::move(rdev)}, metrics_{*this} {
     durable_entities_.blob_sequence_num = pg_sb_->blob_sequence_num;
     durable_entities_.active_blob_count = pg_sb_->active_blob_count;

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -175,16 +175,15 @@ public:
     /// @brief Called when the replica is being destroyed by nuraft;
     void on_destroy(const homestore::group_id_t& group_id) override;
 
-    /// Not Implemented
-    /// @brief Called when the snapshot is being created by nuraft;
+    // Snapshot related functions
     homestore::AsyncReplResult<> create_snapshot(std::shared_ptr< homestore::snapshot_context > context) override;
-    virtual bool apply_snapshot(std::shared_ptr< homestore::snapshot_context > context) override;
-    virtual std::shared_ptr< homestore::snapshot_context > last_snapshot() override;
-    virtual int read_snapshot_obj(std::shared_ptr< homestore::snapshot_context > context,
-                                   std::shared_ptr< homestore::snapshot_obj > snp_obj) override;
-    virtual void write_snapshot_obj(std::shared_ptr< homestore::snapshot_context > context,
-                                     std::shared_ptr< homestore::snapshot_obj > snp_obj) override;
-    virtual void free_user_snp_ctx(void*& user_snp_ctx) override;
+    bool apply_snapshot(std::shared_ptr< homestore::snapshot_context > context) override;
+    std::shared_ptr< homestore::snapshot_context > last_snapshot() override;
+    int read_snapshot_obj(std::shared_ptr< homestore::snapshot_context > context,
+                          std::shared_ptr< homestore::snapshot_obj > snp_obj) override;
+    void write_snapshot_obj(std::shared_ptr< homestore::snapshot_context > context,
+                            std::shared_ptr< homestore::snapshot_obj > snp_obj) override;
+    void free_user_snp_ctx(void*& user_snp_ctx) override;
 
 private:
     HSHomeObject* home_object_{nullptr};

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -298,7 +298,7 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
     constexpr uint64_t num_open_shards_per_pg = 2; // Should be less than num_shards_per_pg
     constexpr uint64_t num_batches_per_shard = 5;
     constexpr uint64_t num_blobs_per_batch = 5;
-    constexpr int corrupted_blob_percentage = 10;             // Percentage of blobs with state = CORRUPTED
+    constexpr int corrupted_blob_percentage = 9;              // Percentage of blobs with state = CORRUPTED
     constexpr int unexpected_corrupted_batch_percentage = 15; // Percentage of batches with unexpected data corruption
 
     // We have to create a PG first to init repl_dev


### PR DESCRIPTION
* Introduced a new `snp_rcvr_meta_blk` to record snapshot receiving progress on the follower. Since the `ReplicationStateMachine` instance cannot be directly referenced, the superblock is added to the `HS_PG` struct to act as a broker.
* Enabled the follower to request resumption from the beginning of a specific shard in `write_snapshot_obj`. Adjusted the cursor update handling logic to accommodate this scenario.
* Added a new test case for restarting the follower with a shorter delay to test resumption without causing a leader timeout.