### PR TITLE
Fix bugs in HS dynamic UT framework

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.10"
+    version = "2.2.11"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -308,6 +308,7 @@ std::optional< pg_id_t > HSHomeObject::get_pg_id_with_group_id(homestore::group_
 }
 
 void HSHomeObject::pg_destroy(pg_id_t pg_id) {
+    LOGI("Destroying pg {}", pg_id);
     mark_pg_destroyed(pg_id);
     destroy_shards(pg_id);
     destroy_hs_resources(pg_id);
@@ -331,6 +332,7 @@ void HSHomeObject::mark_pg_destroyed(pg_id_t pg_id) {
     }
     hs_pg->pg_sb_->state = PGState::DESTROYED;
     hs_pg->pg_sb_.write();
+    LOGD("PG {} is marked as destroyed", pg_id);
 }
 
 void HSHomeObject::destroy_hs_resources(pg_id_t pg_id) {
@@ -367,6 +369,9 @@ void HSHomeObject::destroy_pg_index_table(pg_id_t pg_id) {
         index_table_pg_map_.erase(uuid_str);
         hs()->index_service().remove_index_table(hs_pg->index_table_);
         hs_pg->index_table_->destroy();
+        LOGD("PG {} index table is destroyed", pg_id);
+    } else {
+        LOGD("PG {} index table is not found, skip destroy", pg_id);
     }
 }
 

--- a/src/lib/homestore_backend/hs_shard_manager.cpp
+++ b/src/lib/homestore_backend/hs_shard_manager.cpp
@@ -543,6 +543,7 @@ void HSHomeObject::destroy_shards(pg_id_t pg_id) {
         // erase shard in shard map
         _shard_map.erase(shard->info.id);
     }
+    LOGD("Shards in pg {} have all been destroyed", pg_id);
 }
 
 HSHomeObject::HS_Shard::HS_Shard(ShardInfo shard_info, homestore::chunk_num_t p_chunk_id,

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -38,7 +38,11 @@ public:
     void SetUp() override {
         HSHomeObject::_hs_chunk_size = 20 * Mi;
         _obj_inst = std::dynamic_pointer_cast< HSHomeObject >(g_helper->build_new_homeobject());
-        g_helper->sync();
+        if (!g_helper->is_current_testcase_restarted()) {
+            g_helper->bump_sync_point_and_sync();
+        } else {
+            g_helper->sync();
+        }
     }
 
     void TearDown() override {

--- a/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
@@ -292,6 +292,12 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
             // SyncPoint 1(new member): kill itself.
             g_helper->sync();
             kill();
+        } else if (out_member_id == g_helper->my_replica_id()) {
+            LOGINFO("Destroying PG on removed member");
+            while (am_i_in_pg(pg_id)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                LOGINFO("Old member is waiting to leave pg {}", pg_id);
+            }
         }
 
         // SyncPoint 1(others): wait for the new member stop, then P0 will help start it.
@@ -449,6 +455,12 @@ void HomeObjectFixture::RestartLeaderDuringBaselineResyncUsingSigKill(uint64_t f
             g_helper->sync();
             LOGINFO("going to kill leader");
             kill();
+        } else if (out_member_id == g_helper->my_replica_id()) {
+            LOGINFO("Destroying PG on removed member");
+            while (am_i_in_pg(pg_id)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                LOGINFO("Old member is waiting to leave pg {}", pg_id);
+            }
         }
         // SyncPoint 1: tell leader to kill
         g_helper->sync();


### PR DESCRIPTION
1. Introduce intervals between spawning processes to prevent conflicts when accessing config files.
This may cause the following failure
```
unknown file: Failure
C++ exception with description "[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal" thrown in SetUp().
```
2. Bump sync point num by 1000 at the start of each test case to prevent interference.
3. Remove existing `gtest_filter` argument when spawning restarted processes to ensure only the remaining test cases are executed.

------

There are still some random failures witness during local runs which seem to be caused by replica 2 getting stuck at `pg_destroy()` - so I also added some additional changes & logs to make it easier to identify.