### PR TITLE
Add metrics for baseline resync

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.13"
+    version = "2.2.14"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -578,6 +578,10 @@ uint32_t HSHomeObject::HS_PG::open_shards() const {
     return std::count_if(shards_.begin(), shards_.end(), [](auto const& s) { return s->is_open(); });
 }
 
+uint32_t HSHomeObject::HS_PG::get_snp_progress() const {
+    return snp_rcvr_info_sb_->progress.complete_bytes / snp_rcvr_info_sb_->progress.total_bytes;
+}
+
 // NOTE: caller should hold the _pg_lock
 const HSHomeObject::HS_PG* HSHomeObject::_get_hs_pg_unlocked(pg_id_t pg_id) const {
     auto iter = _pg_map.find(pg_id);

--- a/src/lib/homestore_backend/resync_pg_data.fbs
+++ b/src/lib/homestore_backend/resync_pg_data.fbs
@@ -17,6 +17,8 @@ table ResyncPGMetaData {
     shard_seq_num: uint64;       // shard sequence number, used to assign next shard id;
     members : [Member];           // peers;
     shard_ids : [uint64];              // shard ids to transmit;
+    total_blobs_to_transfer : uint64;      // total used bytes of the pg
+    total_bytes_to_transfer : uint64;      // total capacity of the pg
 }
 
 // ResyncPGMetaData schema is the first message(ObjID=0) in the resync data stream

--- a/src/lib/homestore_backend/resync_shard_data.fbs
+++ b/src/lib/homestore_backend/resync_shard_data.fbs
@@ -10,6 +10,7 @@ table ResyncShardMetaData {
     created_time : uint64;               // shard creation time
     last_modified_time : ulong;       // shard last modify time
     total_capacity_bytes : ulong;    // total capacity of the shard
+    total_active_blobs : ulong;        // total blobs in the shard
     vchunk_id : uint16;                     // vchunk id
 }
 

--- a/src/lib/homestore_backend/resync_shard_data.fbs
+++ b/src/lib/homestore_backend/resync_shard_data.fbs
@@ -10,7 +10,6 @@ table ResyncShardMetaData {
     created_time : uint64;               // shard creation time
     last_modified_time : ulong;       // shard last modify time
     total_capacity_bytes : ulong;    // total capacity of the shard
-    total_active_blobs : ulong;        // total blobs in the shard
     vchunk_id : uint16;                     // vchunk id
 }
 

--- a/src/lib/homestore_backend/snapshot_receive_handler.cpp
+++ b/src/lib/homestore_backend/snapshot_receive_handler.cpp
@@ -132,8 +132,6 @@ int HSHomeObject::SnapshotReceiveHandler::process_shard_snapshot_data(ResyncShar
     ctx_->shard_cursor = shard_meta.shard_id();
     ctx_->cur_batch_num = 0;
     std::unique_lock<std::shared_mutex> lock(mutex);
-    ctx_->progress.cur_shard_total_blobs = shard_meta.total_active_blobs();
-    ctx_->progress.cur_shard_complete_blobs = 0;
     return 0;
 }
 
@@ -143,7 +141,6 @@ int HSHomeObject::SnapshotReceiveHandler::process_blobs_snapshot_data(ResyncBlob
     //retry mesg, need to handle duplicate batch, reset progress
     if (ctx_->cur_batch_num == batch_num) {
         std::unique_lock<std::shared_mutex> lock(mutex);
-        ctx_->progress.cur_shard_complete_blobs -= ctx_->progress.cur_batch_blobs;
         ctx_->progress.complete_blobs -= ctx_->progress.cur_batch_blobs;
         ctx_->progress.complete_bytes -= ctx_->progress.cur_batch_bytes;
         ctx_->progress.cur_batch_blobs = 0;
@@ -303,7 +300,6 @@ int HSHomeObject::SnapshotReceiveHandler::process_blobs_snapshot_data(ResyncBlob
         std::unique_lock<std::shared_mutex> lock(mutex);
         ctx_->progress.cur_batch_blobs = data_blobs.blob_list()->size();
         ctx_->progress.cur_batch_bytes = total_bytes;
-        ctx_->progress.cur_shard_complete_blobs += ctx_->progress.cur_batch_blobs;
         ctx_->progress.complete_blobs += ctx_->progress.cur_batch_blobs;
         ctx_->progress.complete_bytes += ctx_->progress.cur_batch_bytes;
     }

--- a/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
+++ b/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
@@ -201,7 +201,7 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
     ASSERT_TRUE(r_dev.hasValue());
 
     auto handler = std::make_unique< homeobject::HSHomeObject::SnapshotReceiveHandler >(*_obj_inst, r_dev.value());
-    handler->reset_context(snp_lsn, pg_id);
+    handler->reset_context_and_metrics(snp_lsn, pg_id);
 
     // Step 1: Test write pg meta - cannot test full logic since the PG already exists
     // Generate ResyncPGMetaData message

--- a/src/lib/homestore_backend/tests/test_homestore_backend.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend.cpp
@@ -40,7 +40,9 @@ SISL_OPTION_GROUP(
     (num_shards, "", "num_shards", "number of shards", ::cxxopts::value< uint64_t >()->default_value("4"), "number"),
     (num_blobs, "", "num_blobs", "number of blobs", ::cxxopts::value< uint64_t >()->default_value("20"), "number"),
     (is_restart, "", "is_restart", "the process is restart or the first start", ::cxxopts::value< bool >()->
-        default_value("false"), "true or false"));
+        default_value("false"), "true or false"),
+    (enable_http, "", "enable_http", "enable http server or not",
+        ::cxxopts::value< bool >()->default_value("false"), "true or false"));
 
 SISL_LOGGING_INIT(homeobject)
 #define test_options logging, config, homeobject, test_homeobject_repl_common

--- a/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
@@ -531,7 +531,9 @@ SISL_OPTION_GROUP(
     (num_blobs, "", "num_blobs", "number of blobs", ::cxxopts::value< uint64_t >()->default_value("20"), "number"),
     (is_restart, "", "is_restart",
      "(internal) the process is restart or the first start, only used for the first testcase",
-     ::cxxopts::value< bool >()->default_value("false"), "true or false"));
+     ::cxxopts::value< bool >()->default_value("false"), "true or false"),
+    (enable_http, "", "enable_http", "enable http server or not",
+        ::cxxopts::value< bool >()->default_value("false"), "true or false"));
 
 SISL_LOGGING_INIT(homeobject)
 #define test_options logging, config, homeobject, test_homeobject_repl_common


### PR DESCRIPTION
Add statistic information to the pg meta/shard meta message.
Add metrics to track the progress.
- DonerSnapshotMetrics is in memory;
- ReceiverSnapshotMetrics persists the progress. 

Currently, use `DefaultBucket` for histogram metrics. We can refine it after the BR performance test.