### PR TITLE
Ensure CP flush is triggered during `pg_destroy`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.13"
+    version = "2.2.14"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -403,7 +403,8 @@ void HSHomeObject::destroy_pg_index_table(pg_id_t pg_id) {
 void HSHomeObject::destroy_pg_superblk(pg_id_t pg_id) {
     // pay attention: cp_flush will try get '_pg_lock' to flush all pg ops.
     // before destroy pg superblk, we must ensure all ops on this pg are persisted
-    auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(false /* force */);
+    // set force=true to ensure cp flush is triggered
+    auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(true /* force */);
     auto on_complete = [&](auto success) {
         RELEASE_ASSERT(success, "Failed to trigger CP flush");
         LOGI("CP Flush trigged by pg_destroy completed, pg_id={}", pg_id);

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -511,7 +511,7 @@ private:
     }
 
     void trigger_cp(bool wait) {
-        auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(false /* force */);
+        auto fut = homestore::hs()->cp_mgr().trigger_cp_flush(true /* force */);
         auto on_complete = [&](auto success) {
             EXPECT_EQ(success, true);
             LOGINFO("CP Flush completed");


### PR DESCRIPTION
HS uses the `force` parameter to determine the action when a previous checkpoint is being flushed:
- If `force` is set to `false`, HS will directly return `false`.
- If `force` is set to `true`, HS will add it to the back-to-back queue and return a future. This is required for `pg_destroy`.