### PR TITLE
Fix UT

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.2.15"
+    version = "2.2.16"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -49,7 +49,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[>=6.7.1]@oss/master")
+        self.requires("homestore/[>=6.7.2]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/3.3.1", override=True)

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -90,16 +90,19 @@ add_test(NAME HomestoreTestReplaceMemberWithBaselineResync
         --override_config homestore_config.consensus.snapshot_freq_distance:13
         --override_config homestore_config.consensus.num_reserved_log_items=13
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
+        --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
         --gtest_filter=HomeObjectFixture.ReplaceMember)
 add_test(NAME HomestoreResyncTestWithFollowerRestart
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
         --override_config homestore_config.consensus.snapshot_freq_distance:13
         --override_config homestore_config.consensus.num_reserved_log_items=13
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
+        --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
         --gtest_filter=HomeObjectFixture.RestartFollower*)
 add_test(NAME HomestoreResyncTestWithLeaderRestart
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
         --override_config homestore_config.consensus.snapshot_freq_distance:13
         --override_config homestore_config.consensus.num_reserved_log_items=13
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
+        --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
         --gtest_filter=HomeObjectFixture.RestartLeader*)

--- a/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
+++ b/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
@@ -281,8 +281,15 @@ public:
             if (is_restart && args_[j].find("--gtest_filter") != std::string::npos) {
                 continue; // Ignore existing gtest_filter
             }
+            if (is_restart && args_[j].find("--replica_num") != std::string::npos) {
+                continue; // Ignore existing replica_num
+            }
+            if (is_restart && args_[j].find("--is_restart") != std::string::npos) {
+                continue; // Ignore existing is_restart
+            }
             fmt::format_to(std::back_inserter(cmd_line), " {}", args_[j]);
         }
+
         LOGINFO("Spawning Homeobject cmd: {}", cmd_line);
         boost::process::child c(boost::process::cmd = cmd_line, proc_grp_);
         c.detach();


### PR DESCRIPTION
- Add ut for graceful shutdown.
- In RestartLeader UT, the actual leader may not be the assigned leader(with highest priority), thus both replica0 and replica1 could be the leader. Let out member process takes the responsibility to spawn process to simulate restart.