### PR TITLE
Handle empty shard in baseline resync

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.0"
+    version = "2.3.1"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -91,6 +91,10 @@ objId HSHomeObject::PGBlobIterator::expected_next_obj_id() {
     if (cur_start_blob_idx_ + cur_batch_blob_count_ < cur_blob_list_.size()) {
         return objId(cur_obj_id_.shard_seq_num, cur_obj_id_.batch_id + 1);
     }
+    // handle empty shard
+    if (cur_obj_id_.batch_id == 0 && cur_blob_list_.empty()) {
+        return objId(cur_obj_id_.shard_seq_num, cur_obj_id_.batch_id + 1);
+    }
     // next shard
     if (cur_shard_idx_ < static_cast< int64_t >(shard_list_.size() - 1)) {
         auto next_shard_seq_num = shard_list_[cur_shard_idx_ + 1].info.id & 0xFFFFFFFFFFFF;

--- a/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
@@ -40,7 +40,8 @@ TEST_F(HomeObjectFixture, ReplaceMember) {
     auto num_shards_per_pg = SISL_OPTIONS["num_shards"].as< uint64_t >();
     auto num_blobs_per_shard = SISL_OPTIONS["num_blobs"].as< uint64_t >() / num_shards_per_pg;
 
-    for (uint64_t j = 0; j < num_shards_per_pg; j++)
+    // last shard is empty shard
+    for (uint64_t j = 0; j < num_shards_per_pg + 1; j++)
         create_shard(pg_id, 64 * Mi);
 
     // we can not share all the shard_id and blob_id among all the replicas including the spare ones, so we need to


### PR DESCRIPTION
Previously, when a shard is empty, follower will ask for data batch 1 after handling the metadata, however the leader expect_next_obj_id will return objId for next shard, which leads to inconsistency objId.