### PR TITLE
add rollback logic for blob and pg op

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.1"
+    version = "2.3.2"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/include/homeobject/blob_manager.hpp
+++ b/src/include/homeobject/blob_manager.hpp
@@ -11,7 +11,7 @@ namespace homeobject {
 
 ENUM(BlobErrorCode, uint16_t, UNKNOWN = 1, TIMEOUT, INVALID_ARG, UNSUPPORTED_OP, NOT_LEADER, REPLICATION_ERROR,
      UNKNOWN_SHARD, UNKNOWN_BLOB, UNKNOWN_PG, CHECKSUM_MISMATCH, READ_FAILED, INDEX_ERROR, SEALED_SHARD, RETRY_REQUEST,
-     SHUTTING_DOWN);
+     SHUTTING_DOWN, ROLL_BACK);
 struct BlobError {
     BlobErrorCode code;
     // set when we are not the current leader of the PG.

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -12,7 +12,7 @@
 namespace homeobject {
 
 ENUM(PGError, uint16_t, UNKNOWN = 1, INVALID_ARG, TIMEOUT, UNKNOWN_PG, NOT_LEADER, UNKNOWN_PEER, UNSUPPORTED_OP,
-     CRC_MISMATCH, NO_SPACE_LEFT, DRIVE_WRITE_ERROR, RETRY_REQUEST, SHUTTING_DOWN);
+     CRC_MISMATCH, NO_SPACE_LEFT, DRIVE_WRITE_ERROR, RETRY_REQUEST, SHUTTING_DOWN, ROLL_BACK);
 
 struct PGMember {
     // Max length is based on homestore::replica_member_info::max_name_len - 1. Last byte is null terminated.

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -733,9 +733,9 @@ public:
                                  shared< homestore::ReplDev > repl_dev, cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     bool on_shard_message_pre_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
-                                     cintrusive< homestore::repl_req_ctx >&);
+                                     cintrusive< homestore::repl_req_ctx >& hs_ctx);
     void on_shard_message_rollback(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
-                                   cintrusive< homestore::repl_req_ctx >&);
+                                   cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     /**
      * @brief Retrieves the chunk number associated with the given shard ID.
@@ -791,9 +791,14 @@ public:
 
     bool pg_exists(pg_id_t pg_id) const;
 
+    void on_create_pg_message_rollback(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
+                                       cintrusive< homestore::repl_req_ctx >& hs_ctx);
+
     cshared< HeapChunkSelector > chunk_selector() const { return chunk_selector_; }
 
     // Blob manager related.
+    void on_blob_message_rollback(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
+                                  cintrusive< homestore::repl_req_ctx >& hs_ctx);
     void on_blob_put_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
                             const homestore::MultiBlkId& pbas, cintrusive< homestore::repl_req_ctx >& hs_ctx);
     void on_blob_del_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key,

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -495,6 +495,7 @@ folly::Future< std::error_code > ReplicationStateMachine::on_fetch_data(const in
     if (0 == header.size()) {
         LOGD("Header is empty, which means this req has been committed at leader, so ignore this request. req lsn {}",
              lsn);
+        RELEASE_ASSERT(lsn != -1, "the lsn of a committed req should not be -1");
         return folly::makeFuture< std::error_code >(std::error_code{});
     }
 

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -492,6 +492,12 @@ void ReplicationStateMachine::set_snapshot_context(std::shared_ptr< homestore::s
 folly::Future< std::error_code > ReplicationStateMachine::on_fetch_data(const int64_t lsn, const sisl::blob& header,
                                                                         const homestore::MultiBlkId& local_blk_id,
                                                                         sisl::sg_list& sgs) {
+    if (0 == header.size()) {
+        LOGD("Header is empty, which means this req has been committed at leader, so ignore this request. req lsn {}",
+             lsn);
+        return folly::makeFuture< std::error_code >(std::error_code{});
+    }
+
     // the lsn here will mostly be -1 ,since this lsn has not been appeneded and thus get no lsn
     // however, there is a corner case that fetch_data happens after push_data is received and log is appended. in this
     // case, lsn will be the corresponding lsn.

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -79,14 +79,23 @@ void ReplicationStateMachine::on_rollback(int64_t lsn, sisl::blob const& header,
         return;
     }
     switch (msg_header->msg_type) {
-    case ReplicationMessageType::CREATE_SHARD_MSG: {
-        home_object_->on_shard_message_rollback(lsn, header, key, ctx);
-        break;
-    }
+    case ReplicationMessageType::CREATE_SHARD_MSG:
     case ReplicationMessageType::SEAL_SHARD_MSG: {
         home_object_->on_shard_message_rollback(lsn, header, key, ctx);
         break;
     }
+
+    case ReplicationMessageType::PUT_BLOB_MSG:
+    case ReplicationMessageType::DEL_BLOB_MSG: {
+        home_object_->on_blob_message_rollback(lsn, header, key, ctx);
+        break;
+    }
+
+    case ReplicationMessageType::CREATE_PG_MSG: {
+        home_object_->on_create_pg_message_rollback(lsn, header, key, ctx);
+        break;
+    }
+
     default: {
         break;
     }
@@ -483,12 +492,15 @@ void ReplicationStateMachine::set_snapshot_context(std::shared_ptr< homestore::s
 folly::Future< std::error_code > ReplicationStateMachine::on_fetch_data(const int64_t lsn, const sisl::blob& header,
                                                                         const homestore::MultiBlkId& local_blk_id,
                                                                         sisl::sg_list& sgs) {
-    // the lsn here will always be -1 ,since this lsn has not been appeneded and thus get no lsn
+    // the lsn here will mostly be -1 ,since this lsn has not been appeneded and thus get no lsn
+    // however, there is a corner case that fetch_data happens after push_data is received and log is appended. in this
+    // case, lsn will be the corresponding lsn.
 
     const ReplicationMessageHeader* msg_header = r_cast< const ReplicationMessageHeader* >(header.cbytes());
 
     if (msg_header->corrupted()) {
-        LOGW("replication message header is corrupted with crc error, lsn:{}", lsn);
+        LOGW("replication message header is corrupted with crc error, lsn: {}, header: {}", lsn,
+             msg_header->to_string());
         return folly::makeFuture< std::error_code >(std::make_error_code(std::errc::bad_message));
     }
 


### PR DESCRIPTION
if leader receives a put_blob , it will increase the pending req counter. and when this put_blob is committed, it will decrease the counter. however, if rollback happens for this pub_blob , the counter will not be decreased, which will lead to hung in graceful shutdown. the same as del_blob and created_pg.