### PR TITLE
do not purge logs when pg destroy

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.4"
+    version = "2.3.5"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -49,7 +49,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[>=6.7.2]@oss/master")
+        self.requires("homestore/[>=6.7.7]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/3.3.1", override=True)

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -361,16 +361,6 @@ void HSHomeObject::mark_pg_destroyed(pg_id_t pg_id) {
 }
 
 void HSHomeObject::destroy_hs_resources(pg_id_t pg_id) {
-    // Step 1: purge on repl dev
-    auto lg = std::scoped_lock(_pg_lock);
-    auto hs_pg = _get_hs_pg_unlocked(pg_id);
-    if (hs_pg == nullptr) {
-        LOGW("destroy repl dev with unknown pg_id {}", pg_id);
-        return;
-    }
-    hs_pg->repl_dev_->purge();
-
-    // Step 2: reset pg chunks
     chunk_selector_->reset_pg_chunks(pg_id);
 }
 


### PR DESCRIPTION
Remove purge on pg_destroy since [purging is not supported on HS](https://github.com/eBay/HomeStore/pull/676) 