### PR TITLE
Reserve space in a chunk

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.7"
+    version = "2.3.8"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -49,7 +49,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[>=6.8.0]@oss/master")
+        self.requires("homestore/[>=6.9.0]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/3.3.1", override=True)

--- a/src/lib/homestore_backend/hs_backend_config.fbs
+++ b/src/lib/homestore_backend/hs_backend_config.fbs
@@ -15,6 +15,9 @@ table HSBackendSettings {
 
     //Snapshot blob load retry count
     snapshot_blob_load_retry: uint8 = 3 (hotswap);
+
+    //Reserved space in a chunk
+    reserved_bytes_in_chunk: uint64 = 16777216 (hotswap);
 }
 
 root_type HSBackendSettings;

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -123,6 +123,10 @@ void HSHomeObject::init_homestore() {
     RELEASE_ASSERT(app_mem_size > 0, "Invalid app_mem_size");
     LOGI("Initialize and start HomeStore with app_mem_size = {}", homestore::in_bytes(app_mem_size));
 
+    if (HS_BACKEND_DYNAMIC_CONFIG(reserved_bytes_in_chunk) > 0) {
+        _hs_reserved_blks = sisl::round_up(HS_BACKEND_DYNAMIC_CONFIG(reserved_bytes_in_chunk) / _data_block_size, 1);
+        LOGI("will reserve {} blks in each chunk", _hs_reserved_blks);
+    }
     std::vector< homestore::dev_info > device_info;
     bool has_data_dev = false;
     bool has_fast_dev = false;

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -47,6 +47,7 @@ private:
     static constexpr uint64_t HS_CHUNK_SIZE = 2 * Gi;
     static constexpr uint32_t _data_block_size = 1024;
     static uint64_t _hs_chunk_size;
+    uint32_t _hs_reserved_blks = 0;
     ///
 
     /// Overridable Helpers
@@ -791,6 +792,8 @@ public:
     bool release_chunk_based_on_create_shard_message(sisl::blob const& header);
 
     bool pg_exists(pg_id_t pg_id) const;
+
+    uint32_t get_reserved_blks() const { return _hs_reserved_blks; }
 
     void on_create_pg_message_rollback(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
                                        cintrusive< homestore::repl_req_ctx >& hs_ctx);

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -1,3 +1,5 @@
+#include "hs_backend_config.hpp"
+
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/string_generator.hpp>
 #include <homestore/replication_service.hpp>
@@ -190,6 +192,7 @@ folly::Expected< HSHomeObject::HS_PG*, PGError > HSHomeObject::local_create_pg(s
     auto index_table = create_index_table();
     auto uuid_str = boost::uuids::to_string(index_table->uuid());
 
+    repl_dev->set_custom_rdev_name(fmt::format("rdev{}", pg_info.id));
     auto hs_pg = std::make_unique< HS_PG >(std::move(pg_info), std::move(repl_dev), index_table, chunk_ids);
     auto ret = hs_pg.get();
     {

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -166,7 +166,7 @@ public:
     /// @param header Header originally passed with repl_dev::write() api on the leader
     /// @return Expected to return blk_alloc_hints for this write
     homestore::ReplResult< homestore::blk_alloc_hints > get_blk_alloc_hints(sisl::blob const& header,
-                                                                            uint32_t data_size) override;
+                                                                            uint32_t data_size, cintrusive< homestore::repl_req_ctx >& hs_ctx) override;
 
     /// @brief Called when replication module is replacing an existing member with a new member
     void on_replace_member(const homestore::replica_member_info& member_out,


### PR DESCRIPTION
There is a side effect introduced by identical layout: After several restarts or leader switch, some garbage would cause NO_SPACE_ERROR on the follower side which leads to PG NotClean(lag and degraded) ultimately. So reserve some space in a chunk to mitigate/avoid this issue.