### PR TITLE
Enhance logging for replication machine and standardize shard_id output

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.8"
+    version = "2.3.9"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/include/homeobject/blob_manager.hpp
+++ b/src/include/homeobject/blob_manager.hpp
@@ -59,9 +59,9 @@ struct formatter< homeobject::BlobError > {
     template < typename FormatContext >
     auto format(homeobject::BlobError const& err, FormatContext& ctx) {
         if (err.current_leader.has_value()) {
-            return fmt::format_to(ctx.out(), "Code: {}, Leader: {}", err.code, err.current_leader.value());
+            return fmt::format_to(ctx.out(), "Code={}, Leader={}", err.code, err.current_leader.value());
         } else {
-            return fmt::format_to(ctx.out(), "Code: {}", err.code);
+            return fmt::format_to(ctx.out(), "Code={}", err.code);
         }
     }
 };

--- a/src/include/homeobject/homeobject.hpp
+++ b/src/include/homeobject/homeobject.hpp
@@ -108,7 +108,7 @@ struct formatter< homeobject::device_info_t > {
         default:
             type = "UNKNOWN";
         }
-        return fmt::format_to(ctx.out(), "Path: {}, Type: {}", device.path.string(), type);
+        return fmt::format_to(ctx.out(), "Path={}, Type={}", device.path.string(), type);
     }
 };
 } // namespace fmt

--- a/src/include/homeobject/pg_manager.hpp
+++ b/src/include/homeobject/pg_manager.hpp
@@ -77,7 +77,7 @@ struct PGStats {
 
         return fmt::format(
             "PGStats: id={}, replica_set_uuid={}, leader={}, num_members={}, total_shards={}, open_shards={}, "
-            "avail_open_shards={}, used_bytes={}, avail_bytes={}, members: {}",
+            "avail_open_shards={}, used_bytes={}, avail_bytes={}, members={}",
             id, boost::uuids::to_string(replica_set_uuid), boost::uuids::to_string(leader_id), num_members,
             total_shards, open_shards, avail_open_shards, used_bytes, avail_bytes, members_str);
     }

--- a/src/lib/homestore_backend/hs_homeobject.cpp
+++ b/src/lib/homestore_backend/hs_homeobject.cpp
@@ -79,7 +79,7 @@ public:
             host_port.first = uri.host();
             host_port.second = uri.port();
         } catch (std::runtime_error const& e) {
-            LOGE("can't extract host from uuid {}, endpoint: {}; error: {}", to_string(uuid), endpoint, e.what());
+            LOGE("can't extract host from uuid {}, endpoint={}; error={}", to_string(uuid), endpoint, e.what());
         }
         return host_port;
     }
@@ -113,7 +113,7 @@ void HSHomeObject::init_homestore() {
     auto app = _application.lock();
     RELEASE_ASSERT(app, "HomeObjectApplication lifetime unexpected!");
 
-    LOGI("Starting iomgr with {} threads, spdk: {}", app->threads(), false);
+    LOGI("Starting iomgr with {} threads, spdk={}", app->threads(), false);
     ioenvironment.with_iomgr(iomgr::iomgr_params{.num_threads = app->threads(), .is_spdk = app->spdk_mode()})
         .with_http_server();
 

--- a/src/lib/homestore_backend/index_kv.cpp
+++ b/src/lib/homestore_backend/index_kv.cpp
@@ -120,7 +120,7 @@ void HSHomeObject::print_btree_index(pg_id_t pg_id) const {
 shared< BlobIndexTable > HSHomeObject::get_index_table(pg_id_t pg_id) {
     auto hs_pg = get_hs_pg(pg_id);
     if (hs_pg == nullptr) {
-        LOGW("PG not found for pg_id={} when getting index table", pg_id);
+        LOGW("PG not found for pg={} when getting index table", pg_id);
         return nullptr;
     }
     RELEASE_ASSERT(hs_pg->index_table_ != nullptr, "Index table not found for PG");

--- a/src/lib/homestore_backend/replication_message.hpp
+++ b/src/lib/homestore_backend/replication_message.hpp
@@ -78,7 +78,7 @@ struct ReplicationMessageHeader : public BaseMessageHeader<ReplicationMessageHea
 
     std::string to_string() const {
         return fmt::format(
-            "magic={:#x} version={} msg_type={} pg_id={} shard_id={} payload_size={} payload_crc={} header_crc={}\n",
+            "magic={:#x} version={} msg_type={} pg={} shard_id={} payload_size={} payload_crc={} header_crc={}\n",
             magic_num, protocol_version, enum_name(msg_type), pg_id, shard_id, payload_size, payload_crc, header_crc);
     }
 };

--- a/src/lib/homestore_backend/tests/homeobj_fixture.hpp
+++ b/src/lib/homestore_backend/tests/homeobj_fixture.hpp
@@ -60,7 +60,7 @@ public:
     void TearDown() override {
         g_helper->sync();
         LOGINFO("Tearing down homeobject replica={}", g_helper->my_replica_id());
-        LOGINFO("Metrics: {}", sisl::MetricsFarm::getInstance().get_result_in_json().dump(2));
+        LOGINFO("Metrics={}", sisl::MetricsFarm::getInstance().get_result_in_json().dump(2));
         g_helper->app->stop_http_server();
         _obj_inst.reset();
         g_helper->delete_homeobject();
@@ -69,7 +69,7 @@ public:
     void restart(uint32_t shutdown_delay_secs = 0u, uint32_t restart_delay_secs = 0u) {
         g_helper->sync();
         LOGINFO("Restarting homeobject replica={}", g_helper->my_replica_id());
-        LOGTRACE("Metrics: {}", sisl::MetricsFarm::getInstance().get_result_in_json().dump(2));
+        LOGTRACE("Metrics={}", sisl::MetricsFarm::getInstance().get_result_in_json().dump(2));
         trigger_cp(true);
         _obj_inst.reset();
         _obj_inst =
@@ -80,7 +80,7 @@ public:
 
     void stop() {
         LOGINFO("Stoping homeobject replica={}", g_helper->my_replica_id());
-        LOGINFO("Metrics: {}", sisl::MetricsFarm::getInstance().get_result_in_json().dump(2));
+        LOGINFO("Metrics={}", sisl::MetricsFarm::getInstance().get_result_in_json().dump(2));
         _obj_inst.reset();
         g_helper->homeobj_.reset();
         sleep(120);
@@ -135,13 +135,13 @@ public:
             }
             auto p = _obj_inst->pg_manager()->create_pg(std::move(info)).get();
             ASSERT_TRUE(p);
-            LOGINFO("pg {} is created at leader", pg_id);
+            LOGINFO("pg={} is created at leader", pg_id);
         } else {
             // follower need to wait for pg creation to complete locally
             while (!pg_exist(pg_id)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
             }
-            LOGINFO("pg {} is created at follower", pg_id);
+            LOGINFO("pg={} is created at follower", pg_id);
         }
     }
 
@@ -249,14 +249,14 @@ public:
                     run_on_pg_leader(pg_id, [&]() {
                         auto put_blob = build_blob(current_blob_id);
 
-                        LOGINFO("Put blob pg {} shard {} blob {} size {} data {}", pg_id, shard_id, current_blob_id,
+                        LOGINFO("Put blob pg={} shard {} blob {} size {} data {}", pg_id, shard_id, current_blob_id,
                                 put_blob.body.size(),
                                 hex_bytes(put_blob.body.cbytes(), std::min(10u, put_blob.body.size())));
 
                         auto b = _obj_inst->blob_manager()->put(shard_id, std::move(put_blob)).get();
 
                         if (!b) {
-                            LOGERROR("Failed to put blob pg {} shard {} error={}", pg_id, shard_id, b.error());
+                            LOGERROR("Failed to put blob pg={} shard {} error={}", pg_id, shard_id, b.error());
                             ASSERT_TRUE(false);
                         }
 
@@ -273,7 +273,7 @@ public:
             pg_blob_id[pg_id] = current_blob_id;
             auto last_blob_id = pg_blob_id[pg_id] - 1;
             while (!blob_exist(shard_id, last_blob_id)) {
-                LOGINFO("waiting for pg_id {} blob {} to be created locally", pg_id, last_blob_id);
+                LOGINFO("waiting for pg={} blob {} to be created locally", pg_id, last_blob_id);
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
             }
             LOGINFO("shard {} blob {} is created locally, which means all the blob before {} are created", shard_id,
@@ -286,7 +286,7 @@ public:
         run_on_pg_leader(pg_id, [&]() {
             auto g = _obj_inst->blob_manager()->del(shard_id, blob_id).get();
             ASSERT_TRUE(g);
-            LOGINFO("delete blob, pg {} shard {} blob {}", pg_id, shard_id, blob_id);
+            LOGINFO("delete blob, pg={} shard {} blob {}", pg_id, shard_id, blob_id);
         });
         while (blob_exist(shard_id, blob_id)) {
             LOGINFO("waiting for shard {} blob {} to be deleted locally", shard_id, blob_id);
@@ -335,7 +335,7 @@ public:
             if (pg_start_blob_id.find(pg_id) != pg_start_blob_id.end()) current_blob_id = pg_start_blob_id[pg_id];
             for (const auto& shard_id : shard_vec) {
                 for (uint64_t k = 0; k < num_blobs_per_shard; k++) {
-                    LOGDEBUG("going to verify blob pg {} shard {} blob {}", pg_id, shard_id, current_blob_id);
+                    LOGDEBUG("going to verify blob pg={} shard {} blob {}", pg_id, shard_id, current_blob_id);
                     auto blob = build_blob(current_blob_id);
                     len = blob.body.size();
                     if (use_random_offset) {
@@ -357,7 +357,7 @@ public:
                     ASSERT_TRUE(!!g) << "get blob fail, shard_id " << shard_id << " blob_id " << current_blob_id
                                      << " replica number " << g_helper->replica_num();
                     auto result = std::move(g.value());
-                    LOGINFO("get blob pg {} shard {} blob {} off {} len {} data {}", pg_id, shard_id, current_blob_id,
+                    LOGINFO("get blob pg={} shard {} blob {} off {} len {} data {}", pg_id, shard_id, current_blob_id,
                             off, len, hex_bytes(result.body.cbytes(), std::min(len, 10u)));
                     EXPECT_EQ(result.body.size(), len);
                     EXPECT_EQ(std::memcmp(result.body.bytes(), blob.body.cbytes() + off, result.body.size()), 0);

--- a/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
+++ b/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
@@ -9,7 +9,7 @@ TEST_F(HomeObjectFixture, HSHomeObjectCPTestBasic) {
     create_pg(1 /* pg_id */);
     auto shard_info = create_shard(1 /* pg_id */, 64 * Mi);
     pg_shard_id_vec.emplace_back(1 /* pg_id */, shard_info.id);
-    LOGINFO("pg {} shard {}", 1, shard_info.id);
+    LOGINFO("pg={} shard {}", 1, shard_info.id);
     {
         // Step-2: write some dirty pg information and add to dirt list;
         auto lg = std::unique_lock(_obj_inst->_pg_lock);
@@ -53,7 +53,7 @@ TEST_F(HomeObjectFixture, PGBlobIterator) {
     for (uint64_t i = 0; i < num_shards_per_pg; i++) {
         auto shard = create_shard(pg_id, 64 * Mi);
         if (i != empty_shard_seq - 1) { shard_list.emplace_back(shard.id); }
-        LOGINFO("pg {} shard {}", pg_id, shard.id);
+        LOGINFO("pg={} shard {}", pg_id, shard.id);
     }
     pg_blob_id[pg_id] = 0;
     put_blobs(pg_shard_id_vec, num_blobs_per_shard, pg_blob_id);
@@ -175,7 +175,7 @@ TEST_F(HomeObjectFixture, PGBlobIterator) {
                 ASSERT_TRUE(
                     memcmp(result.body.cbytes(), blob_data + blob_header->data_offset, blob_header->blob_size) == 0);
                 packed_blob_size++;
-                LOGDEBUG("[{}]Get blob pg {}, shard {}, blob {}, data_len {}, blob_len {}, header_len {}, user_key_len "
+                LOGDEBUG("[{}]Get blob pg={}, shard {}, blob {}, data_len {}, blob_len {}, header_len {}, user_key_len "
                          "{}, data {}",
                          packed_blob_size, pg->pg_info_.id, shard->info.id, b->blob_id(), b->data()->size(),
                          blob_header->blob_size, sizeof(HSHomeObject::BlobHeader), blob_header->user_key_size,
@@ -217,7 +217,7 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
 
     // Step 1: Test write pg meta - cannot test full logic since the PG already exists
     // Generate ResyncPGMetaData message
-    LOGINFO("TESTING: applying meta for pg {}", pg_id);
+    LOGINFO("TESTING: applying meta for pg={}", pg_id);
     constexpr auto blob_seq_num = num_shards_per_pg * num_batches_per_shard * num_blobs_per_batch;
     flatbuffers::FlatBufferBuilder builder;
     std::vector< flatbuffers::Offset< Member > > members;

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -31,7 +31,7 @@ TEST_F(HomeObjectFixture, BasicPutGetDelBlobWithRestart) {
         for (uint64_t j = 0; j < num_shards_per_pg; j++) {
             auto shard = create_shard(i, 64 * Mi);
             pg_shard_id_vec[i].emplace_back(shard.id);
-            LOGINFO("pg {} shard {}", i, shard.id);
+            LOGINFO("pg={} shard {}", i, shard.id);
         }
     }
 
@@ -169,7 +169,7 @@ TEST_F(HomeObjectFixture, BasicPutGetBlobWithPushDataDisabled) {
         for (uint64_t j = 0; j < num_shards_per_pg; j++) {
             auto shard = create_shard(i, 64 * Mi);
             pg_shard_id_vec[i].emplace_back(shard.id);
-            LOGINFO("pg {} shard {}", i, shard.id);
+            LOGINFO("pg={} shard {}", i, shard.id);
         }
     }
 

--- a/src/lib/homestore_backend/tests/hs_pg_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_pg_tests.cpp
@@ -34,7 +34,7 @@ TEST_F(HomeObjectFixture, PGStatsTest) {
 
     PGStats pg_stats;
     auto res = _obj_inst->pg_manager()->get_stats(pg_id, pg_stats);
-    LOGINFO("stats: {}", pg_stats.to_string());
+    LOGINFO("stats={}", pg_stats.to_string());
 
     EXPECT_EQ(res, true);
     EXPECT_EQ(pg_stats.id, pg_id);
@@ -44,7 +44,7 @@ TEST_F(HomeObjectFixture, PGStatsTest) {
     EXPECT_EQ(pg_stats.num_members, g_helper->members().size());
 
     auto stats = _obj_inst->get_stats();
-    LOGINFO("HomeObj stats: {}", stats.to_string());
+    LOGINFO("HomeObj stats={}", stats.to_string());
 }
 
 TEST_F(HomeObjectFixture, PGExceedSpaceTest) {
@@ -75,7 +75,7 @@ TEST_F(HomeObjectFixture, PGExceedSpaceTest) {
             auto current_time = std::chrono::steady_clock::now();
             auto duration = std::chrono::duration_cast< std::chrono::seconds >(current_time - start_time).count();
             if (duration >= 20) {
-                LOGINFO("Failed to create pg {} at follower", pg_id);
+                LOGINFO("Failed to create pg={} at follower", pg_id);
                 res = false;
                 break;
             }
@@ -114,7 +114,7 @@ TEST_F(HomeObjectFixture, PGSizeLessThanChunkTest) {
             auto current_time = std::chrono::steady_clock::now();
             auto duration = std::chrono::duration_cast< std::chrono::seconds >(current_time - start_time).count();
             if (duration >= 20) {
-                LOGINFO("Failed to create pg {} at follower", pg_id);
+                LOGINFO("Failed to create pg={} at follower", pg_id);
                 res = false;
                 break;
             }
@@ -176,7 +176,7 @@ TEST_F(HomeObjectFixture, ConcurrencyCreatePG) {
     // verify all pgs are created
     for (pg_id_t i = 1; i <= pg_num; ++i) {
         ASSERT_TRUE(pg_exist(i));
-        LOGINFO("Create pg {} successfully", i);
+        LOGINFO("Create pg={} successfully", i);
     }
 }
 
@@ -218,7 +218,7 @@ TEST_F(HomeObjectFixture, CreatePGFailed) {
             std::this_thread::sleep_for(std::chrono::seconds(70));
             int num_repl = 0;
             _obj_inst->hs_repl_service().iterate_repl_devs([&num_repl](cshared< homestore::ReplDev >&) { num_repl++; });
-            LOGINFO("Failed to create pg {} at leader, times {}， num_repl {}", pg_id, i, num_repl);
+            LOGINFO("Failed to create pg={} at leader, times {}， num_repl {}", pg_id, i, num_repl);
             ASSERT_EQ(0, num_repl);
 
         } else {
@@ -229,7 +229,7 @@ TEST_F(HomeObjectFixture, CreatePGFailed) {
                 auto current_time = std::chrono::steady_clock::now();
                 auto duration = std::chrono::duration_cast< std::chrono::seconds >(current_time - start_time).count();
                 if (duration >= 20) {
-                    LOGINFO("Failed to create pg {} at follower", pg_id);
+                    LOGINFO("Failed to create pg={} at follower", pg_id);
                     res = false;
                     break;
                 }
@@ -244,7 +244,7 @@ TEST_F(HomeObjectFixture, CreatePGFailed) {
     auto const pg_id = 1;
     create_pg(pg_id);
     ASSERT_TRUE(pg_exist(pg_id));
-    LOGINFO("create pg {} successfully", pg_id);
+    LOGINFO("create pg={} successfully", pg_id);
     restart();
     ASSERT_TRUE(pg_exist(pg_id));
 }

--- a/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
+++ b/src/lib/homestore_backend/tests/hs_repl_test_helper.hpp
@@ -280,7 +280,7 @@ public:
                     }
                 }
             }
-            LOGINFO("Restart, gtest filter pattern: {}", pattern);
+            LOGINFO("Restart, gtest filter pattern={}", pattern);
             if ("" != pattern) { fmt::format_to(std::back_inserter(cmd_line), " --gtest_filter={}", pattern); }
         }
         for (int j{1}; j < (int)args_.size(); ++j) {
@@ -296,7 +296,7 @@ public:
             fmt::format_to(std::back_inserter(cmd_line), " {}", args_[j]);
         }
 
-        LOGINFO("Spawning Homeobject cmd: {}", cmd_line);
+        LOGINFO("Spawning Homeobject cmd={}", cmd_line);
         boost::process::child c(boost::process::cmd = cmd_line, proc_grp_);
         c.detach();
     }

--- a/src/lib/homestore_backend/tests/hs_shard_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_shard_tests.cpp
@@ -98,7 +98,7 @@ TEST_F(HomeObjectFixture, SealShard) {
             auto current_time = std::chrono::steady_clock::now();
             auto duration = std::chrono::duration_cast< std::chrono::seconds >(current_time - start_time).count();
             if (duration >= 20) {
-                LOGINFO("Failed to create shard at pg {}", pg_id);
+                LOGINFO("Failed to create shard at pg={}", pg_id);
                 res = false;
                 break;
             }

--- a/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
@@ -103,7 +103,7 @@ TEST_F(HomeObjectFixture, ReplaceMember) {
     if (in_member_id == g_helper->my_replica_id()) {
         while (!am_i_in_pg(pg_id)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-            LOGINFO("new member is waiting to become a member of pg {}", pg_id);
+            LOGINFO("new member is waiting to become a member of pg={}", pg_id);
         }
 
         wait_for_blob(pg_shard_id_vec[pg_id].back() /*the last shard id in this pg*/,
@@ -123,7 +123,7 @@ TEST_F(HomeObjectFixture, ReplaceMember) {
     if (out_member_id == g_helper->my_replica_id()) {
         while (am_i_in_pg(pg_id)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-            LOGINFO("old member is waiting to leave pg {}", pg_id);
+            LOGINFO("old member is waiting to leave pg={}", pg_id);
         }
         verify_pg_destroy(pg_id, index_table_uuid_str, pg_shard_id_vec[pg_id], true);
         // since this case out_member don't have any pg, so we can check each chunk.
@@ -236,7 +236,7 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
 #ifdef _PRERELEASE
     if (!is_restart && in_member_id == g_helper->my_replica_id()) {
         if (restart_phase == RECEIVING_SNAPSHOT) {
-            LOGINFO("Test case: restart follower when receiving snapshot: {}", restart_phase);
+            LOGINFO("Test case: restart follower when receiving snapshot={}", restart_phase);
             flip::FlipCondition cond;
             // will only delay the snapshot with blob id 11 during which restart will happen
             m_fc.create_condition("blob_id", flip::Operator::EQUAL, static_cast< long >(11), &cond);
@@ -246,16 +246,16 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
             kill_until_shard = pg_shard_id_vec[pg_id].front();
             kill_until_blob = num_blobs_per_shard - 1;
         } else if (restart_phase == APPLYING_SNAPSHOT) {
-            LOGINFO("Test case: restart follower when applying snapshot: {}", restart_phase);
+            LOGINFO("Test case: restart follower when applying snapshot={}", restart_phase);
             set_retval_flip("simulate_apply_snapshot_delay", static_cast< long >(flip_delay) /*ms*/, 1, 100);
         } else if (restart_phase == TRUNCATING_LOGS) {
             flip::FlipCondition cond;
             // TODO This flip should be added in homestore
             m_fc.create_condition("compact_lsn", flip::Operator::EQUAL, static_cast< long >(26), &cond);
-            LOGINFO("Test case: restart follower when truncating logs: {}", restart_phase);
+            LOGINFO("Test case: restart follower when truncating logs={}", restart_phase);
             set_retval_flip("simulate_truncate_log_delay", static_cast< long >(flip_delay) /*ms*/, 1, 100, cond);
         } else {
-            LOGWARN("restart after baseline resync: {}", restart_phase);
+            LOGWARN("restart after baseline resync={}", restart_phase);
         }
     }
 #endif
@@ -286,9 +286,9 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
         if (in_member_id == g_helper->my_replica_id()) {
             while (!am_i_in_pg(pg_id)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-                LOGINFO("new member is waiting to become a member of pg {}", pg_id);
+                LOGINFO("new member is waiting to become a member of pg={}", pg_id);
             }
-            LOGDEBUG("wait for the data[shard:{}, blob:{}] replicated to the new member", kill_until_shard,
+            LOGDEBUG("wait for the data[shard={}, blob={}] replicated to the new member", kill_until_shard,
                      kill_until_blob);
             wait_for_blob(kill_until_shard, kill_until_blob);
             LOGINFO("about to kill new member")
@@ -300,7 +300,7 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
             LOGINFO("Destroying PG on removed member");
             while (am_i_in_pg(pg_id)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-                LOGINFO("Old member is waiting to leave pg {}", pg_id);
+                LOGINFO("Old member is waiting to leave pg={}", pg_id);
             }
         }
 
@@ -328,7 +328,7 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
         // new member restart
         while (!am_i_in_pg(pg_id)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-            LOGINFO("new member is waiting to become a member of pg {}", pg_id);
+            LOGINFO("new member is waiting to become a member of pg={}", pg_id);
         }
         run_if_in_pg(pg_id, [&]() {
             wait_for_blob(last_shard, last_blob);
@@ -415,9 +415,9 @@ TEST_F(HomeObjectFixture, RestartFollowerDuringBaselineResyncUsingGracefulShutdo
     if (in_member_id == g_helper->my_replica_id()) {
         while (!am_i_in_pg(pg_id)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
-            LOGINFO("new member is waiting to become a member of pg {}", pg_id);
+            LOGINFO("new member is waiting to become a member of pg={}", pg_id);
         }
-        LOGDEBUG("wait for the data[shard:{}, blob:{}] replicated to the new member", kill_until_shard,
+        LOGDEBUG("wait for the data[shard={}, blob={}] replicated to the new member", kill_until_shard,
                  kill_until_blob);
         wait_for_blob(kill_until_shard, kill_until_blob);
         LOGINFO("about to restart new member")
@@ -432,7 +432,7 @@ TEST_F(HomeObjectFixture, RestartFollowerDuringBaselineResyncUsingGracefulShutdo
         LOGINFO("Destroying PG on removed member");
         while (am_i_in_pg(pg_id)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
-            LOGINFO("Old member is waiting to leave pg {}", pg_id);
+            LOGINFO("Old member is waiting to leave pg={}", pg_id);
         }
     }
     g_helper->sync();
@@ -498,7 +498,7 @@ void HomeObjectFixture::RestartLeaderDuringBaselineResyncUsingSigKill(uint64_t f
 #ifdef _PRERELEASE
         if (initial_leader_replica_num == g_helper->replica_num()) {
             if (restart_phase == RECEIVING_SNAPSHOT) {
-                LOGINFO("restart when receiving snapshot: {}, kill_until_shard={}, kill_until_blob={}", restart_phase,
+                LOGINFO("restart when receiving snapshot={}, kill_until_shard={}, kill_until_blob={}", restart_phase,
                         kill_until_shard, kill_until_blob);
                 flip::FlipCondition cond;
                 // will only delay the snapshot with blob id 7 during which restart will happen
@@ -506,10 +506,10 @@ void HomeObjectFixture::RestartLeaderDuringBaselineResyncUsingSigKill(uint64_t f
                 set_retval_flip("simulate_read_snapshot_load_blob_delay", static_cast< long >(flip_delay) /*ms*/, 1,
                                 100, cond);
             } else if (restart_phase == APPLYING_SNAPSHOT) {
-                LOGINFO("restart when applying snapshot: {}", restart_phase);
+                LOGINFO("restart when applying snapshot={}", restart_phase);
                 set_retval_flip("simulate_apply_snapshot_delay", static_cast< long >(flip_delay) /*ms*/, 1, 100);
             } else {
-                LOGWARN("restart after baseline resync: {}", restart_phase);
+                LOGWARN("restart after baseline resync={}", restart_phase);
             }
         }
 #endif
@@ -543,9 +543,9 @@ void HomeObjectFixture::RestartLeaderDuringBaselineResyncUsingSigKill(uint64_t f
         if (in_member_id == g_helper->my_replica_id()) {
             while (!am_i_in_pg(pg_id)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-                LOGINFO("new member is waiting to become a member of pg {}", pg_id);
+                LOGINFO("new member is waiting to become a member of pg={}", pg_id);
             }
-            LOGDEBUG("wait for the data[shard:{}, blob:{}] replicated to the new member", kill_until_shard,
+            LOGDEBUG("wait for the data[shard={}, blob={}] replicated to the new member", kill_until_shard,
                      kill_until_blob);
             wait_for_blob(kill_until_shard, kill_until_blob);
         } else if (initial_leader_replica_num == g_helper->replica_num()) {
@@ -557,7 +557,7 @@ void HomeObjectFixture::RestartLeaderDuringBaselineResyncUsingSigKill(uint64_t f
             LOGINFO("Destroying PG on removed member");
             while (am_i_in_pg(pg_id)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
-                LOGINFO("Old member is waiting to leave pg {}", pg_id);
+                LOGINFO("Old member is waiting to leave pg={}", pg_id);
             }
         }
         // SyncPoint 1: tell leader to kill

--- a/src/lib/memory_backend/mem_shard_manager.cpp
+++ b/src/lib/memory_backend/mem_shard_manager.cpp
@@ -17,7 +17,7 @@ ShardManager::AsyncResult< ShardInfo > MemoryHomeObject::_create_shard(pg_id_t p
         auto& s_list = pg_it->second->shards_;
         info.id = make_new_shard_id(pg_owner, s_list.size());
         auto iter = s_list.emplace(s_list.end(), std::make_unique< Shard >(info));
-        LOGDEBUG("Creating Shard [{}]: in Pg [{}] of Size [{}b]", info.id & shard_mask, pg_owner, size_bytes);
+        LOGDEBUG("Creating Shard [{}]: in pg={} of Size [{}b]", info.id & shard_mask, pg_owner, size_bytes);
         auto [_, s_happened] = _shard_map.emplace(info.id, iter);
         RELEASE_ASSERT(s_happened, "Duplicate Shard insertion!");
     }

--- a/src/lib/tests/fixture_app.cpp
+++ b/src/lib/tests/fixture_app.cpp
@@ -57,12 +57,12 @@ void TestFixture::SetUp() {
     ASSERT_TRUE(!!s_e);
     s_e.then([this](auto&& i) { _shard_2 = std::move(i); });
 
-    LOGDEBUG("Get on empty Shard: {}", _shard_1.id);
+    LOGDEBUG("Get on empty Shard={}", _shard_1.id);
     auto g_e = homeobj_->blob_manager()->get(_shard_1.id, 0).get();
     ASSERT_FALSE(g_e);
     EXPECT_EQ(homeobject::BlobErrorCode::UNKNOWN_BLOB, g_e.error().getCode());
 
-    LOGDEBUG("Insert Blob to: {}", _shard_1.id);
+    LOGDEBUG("Insert Blob to={}", _shard_1.id);
     auto o_e = homeobj_->blob_manager()
                    ->put(_shard_1.id, homeobject::Blob{sisl::io_blob_safe(4 * Ki, 512u), "test_blob", 4 * Mi})
                    .get();


### PR DESCRIPTION
Standardize logging format across the codebase

- Updated all shardID logs to use the format: shardID=0x{:x},pg={},shard=0x{:x}
- Ensured all pg logs are formatted as: pg={}
- Modified all log entries to follow the key=val format for consistency

This change improves the readability and consistency of log outputs, making it easier to parse and debug.