### PR TITLE
handling config change where we also need to check no_space_left error info

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.15"
+    version = "2.3.16"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -49,7 +49,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[^6.12]@oss/master")
+        self.requires("homestore/[^6.13]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/3.3.1", override=True)

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -43,6 +43,7 @@ void ReplicationStateMachine::on_commit(int64_t lsn, const sisl::blob& header, c
 }
 
 void ReplicationStateMachine::notify_committed_lsn(int64_t lsn) {
+    LOGD("got committed lsn notification , lsn={}", lsn);
     // handle no_space_left error if we have any
     const auto [target_lsn, chunk_id] = get_no_space_left_error_info();
     if (std::numeric_limits< homestore::repl_lsn_t >::max() == target_lsn) {

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -66,8 +66,7 @@ void ReplicationStateMachine::notify_committed_lsn(int64_t lsn) {
     }
 
     if (target_lsn == lsn) {
-        // check if there is pending no_space_left error to be handled. only follower will handle this
-        LOGD("handle no_space_left_error_info, lsn={}, chunk_id={}", lsn, chunk_id);
+        LOGD("match no_space_left_error_info, lsn={}, chunk_id={}", lsn, chunk_id);
         handle_no_space_left(lsn, chunk_id);
         reset_no_space_left_error_info();
     }

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -202,6 +202,24 @@ public:
     // @param chunk_id - on which chunk no_space_left happened
     void on_no_space_left(homestore::repl_lsn_t lsn, homestore::chunk_num_t chunk_id) override;
 
+    /// @brief Called when the config log entry has been rolled backed.
+    ///
+    /// This function is called on followers only when the log entry is going to be overwritten. This function is called
+    /// from a random worker thread, but is guaranteed to be serialized.
+    ///
+    /// For each config log index, it is guaranteed that either on_config_commit() or on_config_rollback() is called but
+    /// not both.
+    /// @param lsn - The log sequence number of the rollbacked config log entry
+    void on_config_rollback(int64_t lsn) override;
+
+    /// @brief periodically called to notify the lastest committed lsn to the listener.
+    /// NOTE: this callback will block the thread of flushing the latest committed lsn into repl_dev superblk as DC_LSN,
+    /// pls take care if there is any heavy or blocking operation in this callback.
+    ///
+    /// @param lsn - The lasted committed log sequence number so far
+    ///
+    void notify_committed_lsn(int64_t lsn) override;
+
 private:
     HSHomeObject* home_object_{nullptr};
 


### PR DESCRIPTION
now that we have continuous notifications of the last committed lsn, we can always set error info and wait until got the notification of this lsn is committed.

this way, we no longer need to pause statemachine and check whether the last append lsn is committed