### PR TITLE
Update blk_size from 1K to 4K to align with the physical sector size of HDDs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.19"
+    version = "2.3.20"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -45,7 +45,7 @@ private:
     inline static auto const _snp_rcvr_meta_name = std::string("SnapshotReceiver");
     inline static auto const _snp_rcvr_shard_list_meta_name = std::string("SnapshotReceiverShardList");
     static constexpr uint64_t HS_CHUNK_SIZE = 2 * Gi;
-    static constexpr uint32_t _data_block_size = 1024;
+    static constexpr uint32_t _data_block_size = 4 * Ki;
     static uint64_t _hs_chunk_size;
     uint32_t _hs_reserved_blks = 0;
     ///


### PR DESCRIPTION
This change also supports larger blob sizes due to the limitation of max_blks_per_blkid
