### PR TITLE
Redesign replace_member

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.3.23"
+    version = "2.4.0"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -49,7 +49,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[^6.13]@oss/master")
+        self.requires("homestore/[~6.15.1]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/3.3.1", override=True)

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -89,7 +89,9 @@ add_test(NAME HomestoreTestReplaceMember
         --override_config homestore_config.consensus.snapshot_freq_distance:0
         --gtest_filter=HomeObjectFixture.ReplaceMember
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
-        --override_config homestore_config.consensus.max_grpc_message_size:138412032)
+        --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
+        --override_config homestore_config.consensus.laggy_threshold=0)
 # To test both baseline & incremental resync functionality, we use 13 to minimize the likelihood of it being a divisor of the total LSN (currently 30)
 add_test(NAME HomestoreTestReplaceMemberWithBaselineResync
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
@@ -98,6 +100,8 @@ add_test(NAME HomestoreTestReplaceMemberWithBaselineResync
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
         --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
+        --override_config homestore_config.consensus.laggy_threshold=0
         --gtest_filter=HomeObjectFixture.ReplaceMember)
 add_test(NAME HomestoreResyncTestWithFollowerRestart
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
@@ -106,6 +110,8 @@ add_test(NAME HomestoreResyncTestWithFollowerRestart
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
         --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
+        --override_config homestore_config.consensus.laggy_threshold=0
         --gtest_filter=HomeObjectFixture.RestartFollower*)
 add_test(NAME HomestoreResyncTestWithLeaderRestart
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
@@ -114,6 +120,8 @@ add_test(NAME HomestoreResyncTestWithLeaderRestart
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
         --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
+        --override_config homestore_config.consensus.laggy_threshold=0
         --gtest_filter=HomeObjectFixture.RestartLeader*)
 
 add_executable(homestore_test_gc)

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -153,7 +153,7 @@ bool HSHomeObject::PGBlobIterator::create_pg_snapshot_data(sisl::io_blob_safe& m
         shard_ids.push_back(shard.info.id);
     }
 
-    auto pg_entry = CreateResyncPGMetaDataDirect(builder_, pg_info.id, &uuid, pg_info.size, pg_info.chunk_size,
+    auto pg_entry = CreateResyncPGMetaDataDirect(builder_, pg_info.id, &uuid, pg_info.size, pg_info.expected_member_num, pg_info.chunk_size,
                                                  pg->durable_entities().blob_sequence_num, pg->shard_sequence_num_,
                                                  &members, &shard_ids, total_blobs, total_bytes);
     builder_.FinishSizePrefixed(pg_entry);

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -171,9 +171,13 @@ public:
     get_blk_alloc_hints(sisl::blob const& header, uint32_t data_size,
                         cintrusive< homestore::repl_req_ctx >& hs_ctx) override;
 
-    /// @brief Called when replication module is replacing an existing member with a new member
-    void on_replace_member(const homestore::replica_member_info& member_out,
-                           const homestore::replica_member_info& member_in) override;
+    /// @brief Called when start replacing an existing member with a new member
+    void on_start_replace_member(const homestore::replica_member_info& member_out,
+                                 const homestore::replica_member_info& member_in, trace_id_t tid = 0) override;
+
+    /// @brief Called when complete replacing an existing member with a new member
+    void on_complete_replace_member(const homestore::replica_member_info& member_out,
+                                    const homestore::replica_member_info& member_in, trace_id_t tid = 0) override;
 
     /// @brief Called when the replica is being destroyed by nuraft;
     void on_destroy(const homestore::group_id_t& group_id) override;

--- a/src/lib/homestore_backend/resync_pg_data.fbs
+++ b/src/lib/homestore_backend/resync_pg_data.fbs
@@ -12,6 +12,7 @@ table ResyncPGMetaData {
     pg_id : uint16;                        // only low 16 bit is used for pg_id;
     replica_set_uuid : [ubyte];    // uuid of replica set
     pg_size : uint64;                   // pg size;
+    expected_member_num: uint32;      // expected number of members in the pg;
     chunk_size : uint64;              // chunk size;
     blob_seq_num : uint64;        // blob sequence number, used to assign next blob id;
     shard_seq_num: uint64;       // shard sequence number, used to assign next shard id;

--- a/src/lib/homestore_backend/snapshot_receive_handler.cpp
+++ b/src/lib/homestore_backend/snapshot_receive_handler.cpp
@@ -25,6 +25,7 @@ int HSHomeObject::SnapshotReceiveHandler::process_pg_snapshot_data(ResyncPGMetaD
     // Create local PG
     PGInfo pg_info(pg_meta.pg_id());
     pg_info.size = pg_meta.pg_size();
+    pg_info.expected_member_num = pg_meta.expected_member_num();
     pg_info.chunk_size = pg_meta.chunk_size();
     std::copy_n(pg_meta.replica_set_uuid()->data(), 16, pg_info.replica_set_uuid.begin());
     for (unsigned int i = 0; i < pg_meta.members()->size(); i++) {
@@ -36,6 +37,7 @@ int HSHomeObject::SnapshotReceiveHandler::process_pg_snapshot_data(ResyncPGMetaD
         pg_member.priority = member->priority();
         pg_info.members.insert(pg_member);
     }
+    LOGI("PG expected member num={}, actual members num={}", pg_info.expected_member_num, pg_meta.members()->size())
 
 #ifdef _PRERELEASE
     if (iomgr_flip::instance()->test_flip("snapshot_receiver_pg_error")) {

--- a/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
+++ b/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
@@ -223,14 +223,14 @@ TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
     std::vector< flatbuffers::Offset< Member > > members;
     std::vector uuid(stats.replica_set_uuid.begin(), stats.replica_set_uuid.end());
     for (auto& member : stats.members) {
-        auto id = std::vector< std::uint8_t >(std::get< 0 >(member).begin(), std::get< 0 >(member).end());
-        members.push_back(CreateMemberDirect(builder, &id, std::get< 1 >(member).c_str(), 100));
+        auto id = std::vector< std::uint8_t >(member.id.begin(), member.id.end());
+        members.push_back(CreateMemberDirect(builder, &id, member.name.c_str(), 100));
     }
     std::vector< uint64_t > shard_ids;
     for (uint64_t i = 1; i <= num_shards_per_pg; i++) {
         shard_ids.push_back(i);
     }
-    auto pg_entry = CreateResyncPGMetaDataDirect(builder, pg_id, &uuid, pg->pg_info_.size, pg->pg_info_.chunk_size,
+    auto pg_entry = CreateResyncPGMetaDataDirect(builder, pg_id, &uuid, pg->pg_info_.size, pg->pg_info_.expected_member_num, pg->pg_info_.chunk_size,
                                                  blob_seq_num, num_shards_per_pg, &members, &shard_ids);
     builder.Finish(pg_entry);
     auto pg_meta = GetResyncPGMetaData(builder.GetBufferPointer());

--- a/src/lib/memory_backend/mem_pg_manager.cpp
+++ b/src/lib/memory_backend/mem_pg_manager.cpp
@@ -36,8 +36,7 @@ bool MemoryHomeObject::_get_stats(pg_id_t id, PGStats& stats) const {
     stats.open_shards =
         std::count_if(pg->shards_.begin(), pg->shards_.end(), [](auto const& s) { return s->is_open(); });
     for (auto const& m : pg->pg_info_.members) {
-        stats.members.emplace_back(
-            std::make_tuple(m.id, m.name, 0 /* last commit lsn */, 0 /* last succ response us */));
+        stats.members.emplace_back(peer_info{.id = m.id, .name = m.name});
     }
 
     return true;


### PR DESCRIPTION
HS's replace_member will have two phases:
1. Set the old member to learner and add the new member. This step will call `on_pg_start_replace_member` to notify us.
2. HS takes the responsibility to track the replication progress, and complete the replace member(remove the old
member) when the new member is fully synced.  This step will call `on_pg_complete_replace_member`.

HO relies on these two callback to update PG members.
Define two member related number in PG superblock:
- num_expected_members: How many members a PG should have, mainly used in PG metablk space allocation.
- num_dynamic_members: How many members a PG actually have, used to access members in PG metablk.

Design doc: https://docs.google.com/document/d/18vtBbasnBH6cpxQ4NWwzSM3uWkRfqnEJpElBmmSJPt4/edit?tab=t.0#heading=h.ypyu7i2i9xj6
Rely on HS changes: https://github.com/eBay/HomeStore/pull/727/files