### PR TITLE
Change BlobHeader to include user key and block_hashes.

### DIFF
--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -75,10 +75,6 @@ struct put_blob_req_ctx : public repl_result_ctx< BlobManager::Result< HSHomeObj
         blob_header_idx_ = data_bufs_.size() - 1;
     }
 
-    void copy_user_key(std::string const& user_key) {
-        std::memcpy((blob_header_buf().bytes() + sizeof(HSHomeObject::BlobHeader)), user_key.data(), user_key.size());
-    }
-
     HSHomeObject::BlobHeader* blob_header() { return r_cast< HSHomeObject::BlobHeader* >(blob_header_buf().bytes()); }
     sisl::io_blob_safe& blob_header_buf() { return data_bufs_[blob_header_idx_]; }
 };
@@ -120,8 +116,14 @@ BlobManager::AsyncResult< blob_id_t > HSHomeObject::_put_blob(ShardInfo const& s
         return folly::makeUnexpected(BlobError(BlobErrorCode::RETRY_REQUEST));
     }
 
+    // check user key size
+    if (blob.user_key.size() > BlobHeader::max_user_key_length) {
+        BLOGE(tid, shard.id, new_blob_id, "input user key length > max_user_key_length {}", blob.user_key.size(),
+              BlobHeader::max_user_key_length);
+        return folly::makeUnexpected(BlobError(BlobErrorCode::INVALID_ARG));
+    }
     // Create a put_blob request which allocates for header, key and blob_header, user_key. Data sgs are added later
-    auto req = put_blob_req_ctx::make(sizeof(BlobHeader) + blob.user_key.size());
+    auto req = put_blob_req_ctx::make(sisl::round_up(sizeof(BlobHeader), repl_dev->get_blk_size()));
     req->header()->msg_type = ReplicationMessageType::PUT_BLOB_MSG;
     req->header()->payload_size = 0;
     req->header()->payload_crc = 0;
@@ -150,11 +152,18 @@ BlobManager::AsyncResult< blob_id_t > HSHomeObject::_put_blob(ShardInfo const& s
     req->blob_header()->object_offset = blob.object_off;
 
     // Append the user key information if present.
-    if (!blob.user_key.empty()) { req->copy_user_key(blob.user_key); }
+    if (!blob.user_key.empty()) {
+        std::memcpy(req->blob_header()->user_key, blob.user_key.data(), blob.user_key.size());
+    }
 
     // Set offset of actual data after the blob header and user key (rounded off)
     req->blob_header()->data_offset = req->blob_header_buf().size();
-
+    if (req->blob_header()->data_offset != _data_block_size) {
+        BLOGE(tid, shard.id, new_blob_id, "data offset {}, req->blob_header_buf().size() {}",
+              req->blob_header()->data_offset, req->blob_header_buf().size());
+        RELEASE_ASSERT(req->blob_header()->data_offset == _data_block_size,
+                       "blob header should be one block after padding");
+    }
     // In case blob body is not aligned, create a new aligned buffer and copy the blob body.
     if (((r_cast< uintptr_t >(blob.body.cbytes()) % io_align) != 0) || ((blob_size % io_align) != 0)) {
         // If address or size is not aligned, create a separate aligned buffer and do expensive memcpy.
@@ -341,10 +350,7 @@ BlobManager::AsyncResult< Blob > HSHomeObject::_get_blob_data(const shared< home
                 return folly::makeUnexpected(BlobError(BlobErrorCode::READ_FAILED));
             }
 
-            // Metadata start offset is just after blob header
-            std::string user_key = header->user_key_size
-                ? std::string((const char*)(read_buf.bytes() + sizeof(BlobHeader)), (size_t)header->user_key_size)
-                : std::string{};
+            std::string user_key = std::string((const char*)header->user_key, (size_t)header->user_key_size);
 
             uint8_t const* blob_bytes = read_buf.bytes() + header->data_offset;
             uint8_t computed_hash[BlobHeader::blob_max_hash_len]{};

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -361,6 +361,8 @@ public:
     // Padding of zeroes is added to make sure the whole payload be aligned to device block size.
     struct BlobHeader : DataHeader {
         static constexpr uint64_t blob_max_hash_len = 32;
+        static constexpr uint64_t max_blocks = 64;
+        static constexpr uint64_t max_user_key_length = 1024 + 1;
 
         enum class HashAlgorithm : uint8_t {
             NONE = 0,
@@ -372,12 +374,14 @@ public:
         HashAlgorithm hash_algorithm;
         mutable uint8_t header_hash[blob_max_hash_len]{};
         uint8_t hash[blob_max_hash_len]{};
+        uint8_t block_hashes[max_blocks][blob_max_hash_len]{};
         shard_id_t shard_id;
         blob_id_t blob_id;
         uint32_t blob_size;
         uint64_t object_offset; // Offset of this blob in the object. Provided by GW.
         uint32_t data_offset;   // Offset of actual data blob stored after the metadata.
         uint32_t user_key_size; // Actual size of the user key.
+        uint8_t user_key[max_user_key_length]{};
 
         std::string to_string() const {
             return fmt::format("magic={:#x} version={} shard={:#x} blob_size={} user_size={} algo={} hash={:np}\n",
@@ -426,7 +430,8 @@ public:
         }
     };
 #pragma pack()
-
+    // size of BlobHeader should be smaller than _data_block_size
+    static_assert(sizeof(BlobHeader) < _data_block_size);
     struct BlobInfo {
         shard_id_t shard_id;
         blob_id_t blob_id;
@@ -462,7 +467,7 @@ public:
         BlobManager::AsyncResult< blob_read_result > load_blob_data(const BlobInfo& blob_info);
         bool create_pg_snapshot_data(sisl::io_blob_safe& meta_blob);
         bool create_shard_snapshot_data(sisl::io_blob_safe& meta_blob);
-	bool prefetch_blobs_snapshot_data();
+        bool prefetch_blobs_snapshot_data();
         bool create_blobs_snapshot_data(sisl::io_blob_safe& data_blob);
         void pack_resync_message(sisl::io_blob_safe& dest_blob, SyncMessageType type);
         bool end_of_scan() const;
@@ -504,7 +509,7 @@ public:
         int64_t cur_shard_idx_{-1};
         std::vector< BlobInfo > cur_blob_list_{0};
         uint64_t inflight_prefetch_bytes{0};
-        std::map < blob_id_t, BlobManager::AsyncResult< blob_read_result >> prefetched_blobs;
+        std::map< blob_id_t, BlobManager::AsyncResult< blob_read_result > > prefetched_blobs;
         uint64_t cur_start_blob_idx_{0};
         uint64_t cur_batch_blob_count_{0};
         Clock::time_point cur_batch_start_time_;


### PR DESCRIPTION
As a preparation for partial read support, we need finer granuarity for checksum rather than blob level, so that partial read do not need amplificating to full blob for checksum verification.

support up to 64 blocks which translate to 256k block size when max_blob_size is 16MB.

Also changing user_key inline to blob_header.

Header should be exactly a physical block size (4KB).