### PR TITLE
Fix ut

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.6.6"
+    version = "2.6.7"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
+++ b/src/lib/homestore_backend/tests/test_homestore_backend_dynamic.cpp
@@ -87,7 +87,7 @@ void HomeObjectFixture::RestartFollowerDuringBaselineResyncUsingSigKill(uint64_t
     for (size_t i = num_replicas; i < num_replicas + spare_num_replicas; i++)
         excluding_replicas_in_pg.insert(i);
 
-    create_pg(pg_id, 0 /* pg_leader */, excluding_replicas_in_pg);
+    if (!is_restart) { create_pg(pg_id, 0 /* pg_leader */, excluding_replicas_in_pg); }
 
     // we can not share all the shard_id and blob_id among all the replicas including the spare ones, so we need to
     // derive them by calculating.
@@ -544,7 +544,7 @@ void HomeObjectFixture::RestartLeaderDuringBaselineResyncUsingSigKill(uint64_t f
         excluding_replicas_in_pg.insert(i);
 
     auto initial_leader_replica_num = 1;
-    create_pg(pg_id, initial_leader_replica_num /* pg_leader */, excluding_replicas_in_pg);
+    if (!is_restart) { create_pg(pg_id, initial_leader_replica_num /* pg_leader */, excluding_replicas_in_pg); }
     peer_id_t initial_leader_replica_id = get_leader_id(pg_id);
 
     auto num_shards_per_pg = SISL_OPTIONS["num_shards"].as< uint64_t >();


### PR DESCRIPTION
When using spawn to restart the leader, the leader re-runs the ut and attempts to re-create the PG. Since the PG has been updated by `replace_member`, `create_pg` failed due to differences in PGs. This fix ensures `create_pg` is skipped after the leader restart to avoid the issue.