### PR TITLE
work around range_remove in gc

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.7.2"
+    version = "2.7.3"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -912,11 +912,13 @@ public:
     void destroy_snapshot_sb(homestore::group_id_t group_id);
     const Shard* _get_hs_shard(const shard_id_t shard_id) const;
     std::shared_ptr< GCBlobIndexTable > get_gc_index_table(std::string uuid) const;
+    void remove_gc_index_table(std::string uuid);
+    void destroy_all_gc_index_table();
     void trigger_immediate_gc();
+    std::shared_ptr< GCBlobIndexTable > create_gc_index_table();
 
 private:
     std::shared_ptr< BlobIndexTable > create_pg_index_table();
-    std::shared_ptr< GCBlobIndexTable > create_gc_index_table();
 
     std::pair< bool, homestore::btree_status_t > add_to_index_table(shared< BlobIndexTable > index_table,
                                                                     const BlobInfo& blob_info);


### PR DESCRIPTION
this PR aims to work around range_remove issue casued by indextable. A separate gc index table will be created and destroyed for each gc task, not for a gc actor.