### PR TITLE
Add generic handle logic for non-data-op

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.7.2"
+    version = "2.7.3"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"


### PR DESCRIPTION
This pr avoids the false alarm of corrupted message when HS adds ctrl type log but HO is not updated