### PR TITLE
refactor_create/seal_shard

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.7.7"
+    version = "3.0.1"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"
@@ -50,7 +50,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^12.2]@oss/master", transitive_headers=True)
-        self.requires("homestore/[^6.20.15]@oss/master")
+        self.requires("homestore/[^6.20.20]@oss/master")
         self.requires("iomgr/[^11.3]@oss/master")
         self.requires("lz4/1.9.4", override=True)
         self.requires("openssl/[^3.1]", override=True)

--- a/src/include/homeobject/shard_manager.hpp
+++ b/src/include/homeobject/shard_manager.hpp
@@ -34,7 +34,8 @@ struct ShardInfo {
     shard_id_t id;
     pg_id_t placement_group;
     State state;
-    uint64_t lsn; // created_lsn
+    uint64_t lsn;                   // created_lsn
+    uint64_t sealed_lsn{INT64_MAX}; // sealed_lsn
     uint64_t created_time;
     uint64_t last_modified_time;
     uint64_t available_capacity_bytes;

--- a/src/lib/homestore_backend/gc_manager.hpp
+++ b/src/lib/homestore_backend/gc_manager.hpp
@@ -238,10 +238,6 @@ public:
         pdev_gc_metrics& metrics() { return metrics_; }
 
     private:
-        // utils
-        sisl::sg_list generate_shard_super_blk_sg_list(shard_id_t shard_id);
-
-    private:
         uint32_t m_pdev_id;
         std::shared_ptr< HeapChunkSelector > m_chunk_selector;
         folly::MPMCQueue< chunk_id_t > m_reserved_chunk_queue;

--- a/src/lib/homestore_backend/heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/heap_chunk_selector.cpp
@@ -514,7 +514,7 @@ std::shared_ptr< const std::vector< homestore::chunk_num_t > > HeapChunkSelector
     return p_chunk_ids;
 }
 
-std::optional< homestore::chunk_num_t > HeapChunkSelector::get_most_available_blk_chunk(uint64_t ctx, pg_id_t pg_id) {
+std::optional< homestore::chunk_num_t > HeapChunkSelector::pick_most_available_blk_chunk(uint64_t ctx, pg_id_t pg_id) {
     std::shared_lock lock_guard(m_chunk_selector_mtx);
     auto pg_it = m_per_pg_chunks.find(pg_id);
     if (pg_it == m_per_pg_chunks.end()) {

--- a/src/lib/homestore_backend/heap_chunk_selector.h
+++ b/src/lib/homestore_backend/heap_chunk_selector.h
@@ -126,7 +126,7 @@ public:
      * @param pg_id The ID of the pg.
      * @return An optional chunk_num_t value representing v_chunk_id, or std::nullopt if no space left.
      */
-    std::optional< chunk_num_t > get_most_available_blk_chunk(uint64_t ctx, pg_id_t pg_id);
+    std::optional< chunk_num_t > pick_most_available_blk_chunk(uint64_t ctx, pg_id_t pg_id);
 
     // this should be called on each pg meta blk found
     bool recover_pg_chunks(pg_id_t pg_id, std::vector< chunk_num_t >&& p_chunk_ids);

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -689,7 +689,7 @@ private:
     static ShardInfo deserialize_shard_info(const char* shard_info_str, size_t size);
     static std::string serialize_shard_info(const ShardInfo& info);
     void local_create_shard(ShardInfo shard_info, homestore::chunk_num_t v_chunk_id, homestore::chunk_num_t p_chunk_id,
-                            homestore::blk_count_t blk_count, trace_id_t tid = 0);
+                            trace_id_t tid = 0);
     void add_new_shard_to_map(std::unique_ptr< HS_Shard > shard);
     void update_shard_in_map(const ShardInfo& shard_info);
 
@@ -804,8 +804,8 @@ public:
      * @param repl_dev The replication device.
      * @param hs_ctx The replication request context.
      */
-    void on_shard_message_commit(int64_t lsn, sisl::blob const& header, homestore::MultiBlkId const& blkids,
-                                 shared< homestore::ReplDev > repl_dev, cintrusive< homestore::repl_req_ctx >& hs_ctx);
+    void on_shard_message_commit(int64_t lsn, sisl::blob const& header, shared< homestore::ReplDev > repl_dev,
+                                 cintrusive< homestore::repl_req_ctx >& hs_ctx);
 
     bool on_shard_message_pre_commit(int64_t lsn, sisl::blob const& header, sisl::blob const& key,
                                      cintrusive< homestore::repl_req_ctx >& hs_ctx);
@@ -844,16 +844,6 @@ public:
      *
      */
     void on_replica_restart();
-
-    /**
-     * @brief Extracts the physical chunk ID for create shard from the message.
-     *
-     * @param header The message header that includes the shard_info_superblk, which contains the data necessary for
-     * extracting and mapping the chunk ID.
-     * @return An optional virtual chunk id if the extraction and mapping process is successful, otherwise an empty
-     * optional.
-     */
-    std::optional< homestore::chunk_num_t > resolve_v_chunk_id_from_msg(sisl::blob const& header);
 
     /**
      * @brief Releases a chunk based on the information provided in a CREATE_SHARD message.
@@ -923,6 +913,8 @@ public:
 
     void update_pg_meta_after_gc(const pg_id_t pg_id, const homestore::chunk_num_t move_from_chunk,
                                  const homestore::chunk_num_t move_to_chunk, const uint64_t task_id);
+
+    sisl::sg_list generate_shard_super_blk_sg_list(shard_id_t shard_id);
 
     uint32_t get_pg_tombstone_blob_count(pg_id_t pg_id) const;
 

--- a/src/lib/homestore_backend/hs_pg_manager.cpp
+++ b/src/lib/homestore_backend/hs_pg_manager.cpp
@@ -250,9 +250,8 @@ void HSHomeObject::on_create_pg_message_commit(int64_t lsn, sisl::blob const& he
     auto const* msg_header = r_cast< ReplicationMessageHeader const* >(header.cbytes());
 
     if (msg_header->corrupted()) {
-        LOGE("create PG message header is corrupted , lsn={}; header={}, trace_id={}", lsn, msg_header->to_string(),
-             tid);
-        if (ctx) { ctx->promise_.setValue(folly::makeUnexpected(PGError::CRC_MISMATCH)); }
+        RELEASE_ASSERT(false, "create PG message header is corrupted , lsn={}; header={}, trace_id={}", lsn,
+                       msg_header->to_string(), tid);
         return;
     }
 
@@ -261,8 +260,7 @@ void HSHomeObject::on_create_pg_message_commit(int64_t lsn, sisl::blob const& he
 
     if (crc32_ieee(init_crc32, serailized_pg_info_buf, serailized_pg_info_size) != msg_header->payload_crc) {
         // header & value is inconsistent;
-        LOGE("create PG message header is inconsistent with value, lsn={}, trace_id={}", lsn, tid);
-        if (ctx) { ctx->promise_.setValue(folly::makeUnexpected(PGError::CRC_MISMATCH)); }
+        RELEASE_ASSERT(false, "create PG message header is inconsistent with value, lsn={}, trace_id={}", lsn, tid);
         return;
     }
 
@@ -857,8 +855,8 @@ void HSHomeObject::on_create_pg_message_rollback(int64_t lsn, sisl::blob const& 
     auto const* msg_header = r_cast< ReplicationMessageHeader const* >(header.cbytes());
 
     if (msg_header->corrupted()) {
-        LOGE("create PG message header is corrupted , lsn={}, header={}", lsn, msg_header->to_string());
-        if (ctx) { ctx->promise_.setValue(folly::makeUnexpected(PGError::CRC_MISMATCH)); }
+        RELEASE_ASSERT(false, "create PG message header is corrupted , lsn={}, header={}", lsn,
+                       msg_header->to_string());
         return;
     }
 
@@ -867,8 +865,7 @@ void HSHomeObject::on_create_pg_message_rollback(int64_t lsn, sisl::blob const& 
 
     if (crc32_ieee(init_crc32, serailized_pg_info_buf, serailized_pg_info_size) != msg_header->payload_crc) {
         // header & value is inconsistent;
-        LOGE("create PG message header is inconsistent with value, lsn={}", lsn);
-        if (ctx) { ctx->promise_.setValue(folly::makeUnexpected(PGError::CRC_MISMATCH)); }
+        RELEASE_ASSERT(false, "create PG message header is inconsistent with value, lsn={}", lsn);
         return;
     }
 

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -179,7 +179,7 @@ bool HSHomeObject::PGBlobIterator::generate_shard_blob_list() {
 bool HSHomeObject::PGBlobIterator::create_shard_snapshot_data(sisl::io_blob_safe& meta_blob) {
     auto shard = shard_list_[cur_shard_idx_];
     auto shard_entry = CreateResyncShardMetaData(
-        builder_, shard.info.id, pg_id, static_cast< uint8_t >(shard.info.state), shard.info.lsn,
+        builder_, shard.info.id, pg_id, static_cast< uint8_t >(shard.info.state), shard.info.lsn, shard.info.sealed_lsn,
         shard.info.created_time, shard.info.last_modified_time, shard.info.total_capacity_bytes, shard.v_chunk_num);
 
     builder_.FinishSizePrefixed(shard_entry);

--- a/src/lib/homestore_backend/resync_shard_data.fbs
+++ b/src/lib/homestore_backend/resync_shard_data.fbs
@@ -3,14 +3,15 @@ native_include "sisl/utility/non_null_ptr.hpp";
 namespace homeobject;
 
 table ResyncShardMetaData {
-    shard_id : uint64;                      // shard id to be created with;
+    shard_id : uint64;                         // shard id to be created with;
     pg_id : uint16;                            // pg id which this shard belongs to;
     state : ubyte;                             // shard state;
-    created_lsn : uint64;                 // lsn on shard creation;
-    created_time : uint64;               // shard creation time
-    last_modified_time : ulong;       // shard last modify time
-    total_capacity_bytes : ulong;    // total capacity of the shard
-    vchunk_id : uint16;                     // vchunk id
+    created_lsn : uint64;                      // lsn on shard creation;
+    sealed_lsn : uint64;                       // lsn on shard sealing;
+    created_time : uint64;                     // shard creation time
+    last_modified_time : ulong;                // shard last modify time
+    total_capacity_bytes : ulong;              // total capacity of the shard
+    vchunk_id : uint16;                        // vchunk id
 }
 
 //ShardMetaData schema is the first batch(batch=0) in the shard transmission

--- a/src/lib/homestore_backend/tests/hs_blob_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_blob_tests.cpp
@@ -449,14 +449,6 @@ TEST_F(HomeObjectFixture, BasicPutGetBlobWithPushDataDisabled) {
     // statemachine
     set_basic_flip("disable_leader_push_data", std::numeric_limits< int >::max());
 
-    // set the flip to force to read by index table to exercise reading from the index table is working as expected
-    // 50% percentage will achieve the effect that half of the blobs are read from index table and the other
-    // half are read by blk_id
-
-    // for now, given_buffer will be filled by the first async_read, so this will pass.
-    // TODO:: enhence the logic after we have real gc
-    set_basic_flip("local_blk_data_invalid", std::numeric_limits< int >::max(), 50);
-
     // test recovery with pristine state firstly
     restart();
 
@@ -487,13 +479,7 @@ TEST_F(HomeObjectFixture, BasicPutGetBlobWithPushDataDisabled) {
 
     // Verify the stats
     verify_obj_count(num_pgs, num_blobs_per_shard, num_shards_per_pg, false /* deleted */);
-
-    remove_flip("local_blk_data_invalid");
     remove_flip("disable_leader_push_data");
 }
 
-// TODO:: add a test for no_space_left without flip.
-
 #endif
-
-// TODO:: add more test cases to verify the push data disabled scenario after we have gc

--- a/src/lib/homestore_backend/tests/hs_shard_tests.cpp
+++ b/src/lib/homestore_backend/tests/hs_shard_tests.cpp
@@ -125,8 +125,6 @@ TEST_F(HomeObjectFixture, ShardManagerRecovery) {
     auto shard_info = create_shard(pg_id, Mi);
     auto shard_id = shard_info.id;
     EXPECT_EQ(ShardInfo::State::OPEN, shard_info.state);
-    EXPECT_EQ(Mi, shard_info.total_capacity_bytes);
-    EXPECT_EQ(Mi, shard_info.available_capacity_bytes);
     EXPECT_EQ(pg_id, shard_info.placement_group);
 
     // restart homeobject and check if pg/shard info will be recovered.

--- a/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
+++ b/src/lib/homestore_backend/tests/test_heap_chunk_selector.cpp
@@ -177,7 +177,7 @@ TEST_F(HeapChunkSelectorTest, test_identical_layout) {
         for (int j = 3; j > 0; --j) {
             ASSERT_EQ(pg_chunk_collection->available_blk_count, start_available_blk_count);
 
-            const auto v_chunkID = HCS.get_most_available_blk_chunk(j, pg_id);
+            const auto v_chunkID = HCS.pick_most_available_blk_chunk(j, pg_id);
             ASSERT_TRUE(v_chunkID.has_value());
             p_chunk_id = pg_chunk_collection->m_pg_chunks[v_chunkID.value()]->get_chunk_id();
             ASSERT_EQ(HCS.m_chunks[p_chunk_id]->m_state, ChunkState::INUSE);
@@ -216,7 +216,7 @@ TEST_F(HeapChunkSelectorTest, test_identical_layout) {
             start_available_blk_count -= j;
         }
         // all chunks have been given out
-        ASSERT_FALSE(HCS.get_most_available_blk_chunk(9999, pg_id).has_value());
+        ASSERT_FALSE(HCS.pick_most_available_blk_chunk(9999, pg_id).has_value());
     }
 }
 
@@ -378,7 +378,7 @@ TEST_F(HeapChunkSelectorTest, test_recovery) {
         ASSERT_EQ(pg_chunk_collection->m_pg_chunks[0]->m_state, ChunkState::INUSE);
         ASSERT_EQ(pg_chunk_collection->m_pg_chunks[1]->m_state, ChunkState::AVAILABLE);
 
-        const auto v_chunkID = HCS_recovery.get_most_available_blk_chunk(9999, pg_id);
+        const auto v_chunkID = HCS_recovery.pick_most_available_blk_chunk(9999, pg_id);
         ASSERT_TRUE(v_chunkID.has_value());
         auto chunk = HCS_recovery.select_specific_chunk(pg_id, v_chunkID.value());
         ASSERT_NE(chunk, nullptr);

--- a/src/lib/memory_backend/mem_shard_manager.cpp
+++ b/src/lib/memory_backend/mem_shard_manager.cpp
@@ -10,7 +10,7 @@ ShardManager::AsyncResult< ShardInfo > MemoryHomeObject::_create_shard(pg_id_t p
                                                                        trace_id_t tid) {
     (void)tid;
     auto const now = get_current_timestamp();
-    auto info = ShardInfo(0ull, pg_owner, ShardInfo::State::OPEN, 0, now, now, size_bytes, size_bytes);
+    auto info = ShardInfo(0ull, pg_owner, ShardInfo::State::OPEN, 0, 0, now, now, size_bytes, size_bytes);
     {
         auto lg = std::scoped_lock(_pg_lock, _shard_lock);
         auto pg_it = _pg_map.find(pg_owner);


### PR DESCRIPTION
1 change create/seal shard to log only , so no push_data happens for these two requests.
2 add a check for on_commit put_blob to avoid putting blob to a sealed shard.
3 move select_specific_chunk(mark chunk to inuse state) to on_commit of create_shard.
4 write shard footer for seal shard in baseline resync
5 add a sealed_lsn for shard meta blk, which is not compatible  with previous version