### PR TITLE
Optimize Bucket configs for Histogram

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.7.8"
+    version = "2.7.9"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/gc_manager.hpp
+++ b/src/lib/homestore_backend/gc_manager.hpp
@@ -128,13 +128,13 @@ public:
 
                 // gc task level histogram metrics
                 REGISTER_HISTOGRAM(reclaim_ratio_gc, "the ratio of reclaimed blks to total blks in a gc task",
-                                   HistogramBucketsType(LinearUpto128Buckets)); // 0% to 100% in 128 buckets
+                                   HistogramBucketsType(PercentileBuckets)); // 0% to 100% in 128 buckets
                 REGISTER_HISTOGRAM(
                     gc_time_duration_s_gc, "how long a successful gc task takes by second",
                     HistogramBucketsType(LinearUpto64Buckets)); // gc task is expected to finish within 1 minutes
 
                 REGISTER_HISTOGRAM(reclaim_ratio_egc, "the ratio of reclaimed blks to total blks in an egc task",
-                                   HistogramBucketsType(LinearUpto128Buckets)); // 0% to 100% in 128 buckets
+                                   HistogramBucketsType(PercentileBuckets)); // 0% to 100% in 128 buckets
                 REGISTER_HISTOGRAM(
                     gc_time_duration_s_egc, "how long a successful egc task takes by second",
                     HistogramBucketsType(LinearUpto64Buckets)); // gc task is expected to finish within 1 minutes

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -287,10 +287,6 @@ public:
                 REGISTER_COUNTER(total_user_key_size, "Total user key size provided",
                                  sisl::_publish_as::publish_as_gauge);
 
-                REGISTER_HISTOGRAM(blobs_per_shard,
-                                   "Distribution of blobs per shard"); // TODO: Add a bucket for blob sizes
-                REGISTER_HISTOGRAM(actual_blob_size, "Distribution of actual blob sizes");
-
                 register_me_to_farm();
                 attach_gather_cb(std::bind(&PGMetrics::on_gather, this));
                 blk_size = pg_.repl_dev_->get_blk_size();
@@ -505,13 +501,13 @@ public:
                 REGISTER_COUNTER(snp_dnr_error_count, "Error times when reading blobs in baseline resync");
                 REGISTER_HISTOGRAM(snp_dnr_blob_process_latency,
                                    "Time cost(us) of successfully process a blob in baseline resync",
-                                   HistogramBucketsType(DefaultBuckets));
+                                   HistogramBucketsType(LowResolutionLatecyBuckets));
                 REGISTER_HISTOGRAM(snp_dnr_batch_process_latency,
                                    "Time cost(ms) of successfully process a batch in baseline resync",
-                                   HistogramBucketsType(DefaultBuckets));
+                                   HistogramBucketsType(LowResolutionLatecyBuckets));
                 REGISTER_HISTOGRAM(snp_dnr_batch_e2e_latency,
                                    "Time cost(ms) of a batch end-to-end round trip in baseline resync",
-                                   HistogramBucketsType(DefaultBuckets));
+                                   HistogramBucketsType(LowResolutionLatecyBuckets));
                 register_me_to_farm();
             }
 
@@ -611,10 +607,10 @@ public:
                 REGISTER_GAUGE(snp_rcvr_error_count, "Error count in baseline resync");
                 REGISTER_HISTOGRAM(snp_rcvr_blob_process_time,
                                    "Time cost(us) of successfully process a blob in baseline resync",
-                                   HistogramBucketsType(DefaultBuckets));
+                                   HistogramBucketsType(LowResolutionLatecyBuckets));
                 REGISTER_HISTOGRAM(snp_rcvr_batch_process_time,
                                    "Time cost(ms) of successfully process a batch in baseline resync",
-                                   HistogramBucketsType(DefaultBuckets));
+                                   HistogramBucketsType(LowResolutionLatecyBuckets));
 
                 attach_gather_cb(std::bind(&ReceiverSnapshotMetrics::on_gather, this));
                 register_me_to_farm();

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -39,7 +39,7 @@ HSHomeObject::PGBlobIterator::PGBlobIterator(HSHomeObject& home_obj, homestore::
 // result represents if the objId is valid and the cursors are updated
 bool HSHomeObject::PGBlobIterator::update_cursor(const objId& id) {
     if (cur_batch_start_time_ != Clock::time_point{}) {
-        HISTOGRAM_OBSERVE(*metrics_, snp_dnr_batch_e2e_latency, get_elapsed_time_us(cur_batch_start_time_));
+        HISTOGRAM_OBSERVE(*metrics_, snp_dnr_batch_e2e_latency, get_elapsed_time_ms(cur_batch_start_time_));
     }
     cur_batch_start_time_ = Clock::now();
 
@@ -412,7 +412,7 @@ bool HSHomeObject::PGBlobIterator::create_blobs_snapshot_data(sisl::io_blob_safe
     COUNTER_INCREMENT(*metrics_, snp_dnr_load_blob, blob_entries.size());
     COUNTER_INCREMENT(*metrics_, snp_dnr_load_bytes, total_bytes);
     pack_resync_message(data_blob, SyncMessageType::SHARD_BATCH);
-    HISTOGRAM_OBSERVE(*metrics_, snp_dnr_batch_process_latency, get_elapsed_time_us(batch_start));
+    HISTOGRAM_OBSERVE(*metrics_, snp_dnr_batch_process_latency, get_elapsed_time_ms(batch_start));
     return true;
 }
 

--- a/src/lib/homestore_backend/snapshot_receive_handler.cpp
+++ b/src/lib/homestore_backend/snapshot_receive_handler.cpp
@@ -369,7 +369,7 @@ int HSHomeObject::SnapshotReceiveHandler::process_blobs_snapshot_data(ResyncBlob
         update_snp_info_sb(ctx_->shard_cursor == ctx_->shard_list.front());
     }
 
-    HISTOGRAM_OBSERVE(*metrics_, snp_rcvr_batch_process_time, get_elapsed_time_us(batch_start));
+    HISTOGRAM_OBSERVE(*metrics_, snp_rcvr_batch_process_time, get_elapsed_time_ms(batch_start));
     return 0;
 }
 


### PR DESCRIPTION
1.for latency related metrics, change to use OpLatencyBucket
2.for percentile, use PercentileBuckets.
3.remove some unused (no observation) metrics.