### PR TITLE
Fix snp_dnr_batch_process_latency by using ms.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "2.7.11"
+    version = "2.7.12"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeReplication"

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -318,7 +318,7 @@ bool HSHomeObject::PGBlobIterator::prefetch_blobs_snapshot_data() {
                             COUNTER_INCREMENT(*metrics_, snp_dnr_error_count, 1);
                         } else {
                             LOGT("retrieved blob,  blob={} pbas={}", info.blob_id, info.pbas.to_string());
-                            HISTOGRAM_OBSERVE(*metrics_, snp_dnr_blob_process_latency, get_elapsed_time_us(blob_start));
+                            HISTOGRAM_OBSERVE(*metrics_, snp_dnr_blob_process_latency, get_elapsed_time_ms(blob_start));
                         }
                         return result;
                     }));


### PR DESCRIPTION
The histogram buckets up to 2*1000*1000 which is 2s if we use ns, it is drifted away from the range that a snapshot batch takes.