### PR TITLE
Fix resync tests by enabling log truncation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "3.0.9"
+    version = "3.0.10"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -77,8 +77,9 @@ add_executable(homestore_test_misc)
 target_sources(homestore_test_misc PRIVATE $<TARGET_OBJECTS:homestore_tests_misc>)
 target_link_libraries(homestore_test_misc PUBLIC homeobject_homestore ${COMMON_TEST_DEPS})
 add_test(NAME HomestoreTestMisc COMMAND homestore_test_misc -csv error --executor immediate --config_path ./
-        --override_config homestore_config.consensus.snapshot_freq_distance:0
-        --override_config homestore_config.consensus.max_grpc_message_size:138412032)
+        --override_config homestore_config.consensus.snapshot_freq_distance=0
+        --override_config homestore_config.consensus.max_grpc_message_size=138412032
+        --override_config hs_backend_config.enable_gc=false)
 
 # Dynamic tests
 add_executable(homestore_test_dynamic)
@@ -86,40 +87,43 @@ target_sources(homestore_test_dynamic PRIVATE $<TARGET_OBJECTS:homestore_tests_d
 target_link_libraries(homestore_test_dynamic PUBLIC homeobject_homestore ${COMMON_TEST_DEPS})
 add_test(NAME HomestoreTestReplaceMember
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
-        --override_config homestore_config.consensus.snapshot_freq_distance:0
-        --gtest_filter=HomeObjectFixture.ReplaceMember
+        --override_config homestore_config.consensus.snapshot_freq_distance=0
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
-        --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.max_grpc_message_size=138412032
         --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
-        --override_config homestore_config.consensus.laggy_threshold=2000)
+        --override_config homestore_config.consensus.laggy_threshold=2000
+        --gtest_filter=HomeObjectFixture.ReplaceMember)
 # To test both baseline & incremental resync functionality, we use 13 to minimize the likelihood of it being a divisor of the total LSN (currently 30)
 add_test(NAME HomestoreTestReplaceMemberWithBaselineResync
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
-        --override_config homestore_config.consensus.snapshot_freq_distance:13
+        --override_config homestore_config.consensus.snapshot_freq_distance=13
         --override_config homestore_config.consensus.num_reserved_log_items=13
+        --override_config homestore_config.resource_limits.raft_logstore_reserve_threshold=13
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
-        --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.max_grpc_message_size=138412032
         --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
         --override_config homestore_config.consensus.laggy_threshold=2000
         --gtest_filter=HomeObjectFixture.ReplaceMember)
 add_test(NAME HomestoreResyncTestWithFollowerRestart
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
-        --override_config homestore_config.consensus.snapshot_freq_distance:13
+        --override_config homestore_config.consensus.snapshot_freq_distance=13
         --override_config homestore_config.consensus.num_reserved_log_items=13
+        --override_config homestore_config.resource_limits.raft_logstore_reserve_threshold=13
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
-        --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.max_grpc_message_size=138412032
         --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
         --override_config homestore_config.consensus.laggy_threshold=2000
         --gtest_filter=HomeObjectFixture.RestartFollower*)
 add_test(NAME HomestoreResyncTestWithLeaderRestart
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
-        --override_config homestore_config.consensus.snapshot_freq_distance:13
+        --override_config homestore_config.consensus.snapshot_freq_distance=13
         --override_config homestore_config.consensus.num_reserved_log_items=13
+        --override_config homestore_config.resource_limits.raft_logstore_reserve_threshold=13
         --override_config homestore_config.consensus.snapshot_sync_ctx_timeout_ms=5000
         --override_config homestore_config.generic.repl_dev_cleanup_interval_sec=5
-        --override_config homestore_config.consensus.max_grpc_message_size:138412032
+        --override_config homestore_config.consensus.max_grpc_message_size=138412032
         --override_config homestore_config.consensus.replace_member_sync_check_interval_ms=1000
         --override_config homestore_config.consensus.laggy_threshold=2000
         --gtest_filter=HomeObjectFixture.RestartLeader*)
@@ -127,12 +131,14 @@ add_test(NAME HomestoreResyncTestWithLeaderRestart
 # GC tests
 add_test(NAME FetchDataWithOriginatorGC
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
+        --override_config hs_backend_config.enable_gc=true
         --gtest_filter=HomeObjectFixture.FetchDataWithOriginatorGC)
 
 add_executable(homestore_test_gc)
 target_sources(homestore_test_gc PRIVATE $<TARGET_OBJECTS:homestore_tests_gc>)
 target_link_libraries(homestore_test_gc PUBLIC homeobject_homestore ${COMMON_TEST_DEPS})
 add_test(NAME HomestoreTestGC COMMAND homestore_test_gc -csv error --executor immediate --config_path ./
+        --override_config hs_backend_config.enable_gc=true
         --override_config hs_backend_config.gc_garbage_rate_threshold=0 
         --override_config hs_backend_config.gc_scan_interval_sec=5)
 


### PR DESCRIPTION
Log truncation in resync tests has not worked since [HomeStore#763](https://github.com/eBay/HomeStore/pull/763). 

Add missing raft_logstore_reserve_threshold config and trigger checkpoints on blob writes to enable proper log truncation.