### PR TITLE
BR: fix bug on follower early crash

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "3.0.10"
+    version = "3.0.11"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/snapshot_receive_handler.cpp
+++ b/src/lib/homestore_backend/snapshot_receive_handler.cpp
@@ -444,9 +444,13 @@ bool HSHomeObject::SnapshotReceiveHandler::is_valid_obj_id(const objId& obj_id) 
           obj_id.batch_id == ctx_->cur_batch_num + 1));
 }
 
-shard_id_t HSHomeObject::SnapshotReceiveHandler::get_shard_cursor() const { return ctx_->shard_cursor; }
+shard_id_t HSHomeObject::SnapshotReceiveHandler::get_shard_cursor() const {
+    return ctx_ ? ctx_->shard_cursor : invalid_shard_id;
+}
 
 shard_id_t HSHomeObject::SnapshotReceiveHandler::get_next_shard() const {
+    if (ctx_ == nullptr) { return invalid_shard_id; }
+
     if (ctx_->shard_list.empty()) { return shard_list_end_marker; }
 
     if (ctx_->shard_cursor == 0) { return ctx_->shard_list[0]; }


### PR DESCRIPTION
Follower crashes before first shard completion during baseline resync would leave ctx_ nullptr on restart, causing null dereference when handling resent messages.