### PR TITLE
add a config to allow get_blob without checking traffic ready or not

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "3.0.12"
+    version = "3.0.13"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/CMakeLists.txt
+++ b/src/lib/homestore_backend/CMakeLists.txt
@@ -132,6 +132,7 @@ add_test(NAME HomestoreResyncTestWithLeaderRestart
 add_test(NAME FetchDataWithOriginatorGC
         COMMAND homestore_test_dynamic -csv error --executor immediate --config_path ./
         --override_config hs_backend_config.enable_gc=true
+        --override_config hs_backend_config.gc_enable_read_verify=true
         --gtest_filter=HomeObjectFixture.FetchDataWithOriginatorGC)
 
 add_executable(homestore_test_gc)
@@ -139,6 +140,7 @@ target_sources(homestore_test_gc PRIVATE $<TARGET_OBJECTS:homestore_tests_gc>)
 target_link_libraries(homestore_test_gc PUBLIC homeobject_homestore ${COMMON_TEST_DEPS})
 add_test(NAME HomestoreTestGC COMMAND homestore_test_gc -csv error --executor immediate --config_path ./
         --override_config hs_backend_config.enable_gc=true
+        --override_config hs_backend_config.gc_enable_read_verify=true
         --override_config hs_backend_config.gc_garbage_rate_threshold=0 
         --override_config hs_backend_config.gc_scan_interval_sec=5)
 

--- a/src/lib/homestore_backend/hs_backend_config.fbs
+++ b/src/lib/homestore_backend/hs_backend_config.fbs
@@ -47,6 +47,9 @@ table HSBackendSettings {
     // Number of times to pause the state machine
     state_machine_pause_retry_count: uint8 = 3;
 
+    // Check traffic ready before get, default true, set false for 1-replica workaround mode to allow read
+    check_traffic_ready_before_get: bool = true;
+
 }
 
 root_type HSBackendSettings;


### PR DESCRIPTION
This is a workaround for 1-replica issue