### PR TITLE
Fix pg membership inconsistency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "3.0.17"
+    version = "3.0.18"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"
@@ -50,7 +50,7 @@ class HomeObjectConan(ConanFile):
 
     def requirements(self):
         self.requires("sisl/[^13.0]@oss/master", transitive_headers=True)
-        self.requires("homestore/[^7.1]@oss/master")
+        self.requires("homestore/[^7.3]@oss/master")
         self.requires("iomgr/[^12.0]@oss/master")
 
     def validate(self):

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -789,7 +789,25 @@ public:
                                        const homestore::replica_member_info& member_out,
                                        const homestore::replica_member_info& member_in, trace_id_t tid);
 
+    /**
+     * @brief Called when clean replace member task (rollback)
+     * @param group_id Group ID
+     * @param task_id Task ID
+     * @param member_out Member which should be restored to group
+     * @param member_in Member which should be removed from group
+     * */
+    void on_pg_clean_replace_member_task(homestore::group_id_t group_id, const std::string& task_id,
+                                         const homestore::replica_member_info& member_out,
+                                         const homestore::replica_member_info& member_in, trace_id_t tid);
+
     void on_remove_member(homestore::group_id_t group_id, const peer_id_t& member, trace_id_t tid = 0);
+
+    /**
+     * @brief Reconcile PG membership by synchronizing with raft's actual member list
+     * @param pg_id PG ID to reconcile
+     * @return true if reconciled successfully, false otherwise
+     */
+    bool reconcile_membership(pg_id_t pg_id);
 
     /**
      * @brief Cleans up and recycles resources for the PG identified by the given pg_id on the current node.

--- a/src/lib/homestore_backend/hs_http_manager.hpp
+++ b/src/lib/homestore_backend/hs_http_manager.hpp
@@ -37,6 +37,7 @@ private:
     void remove_member(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void clean_replace_member_task(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void list_pg_replace_member_task(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+    void reconcile_membership(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void get_pg_quorum(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void exit_pg(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -274,6 +274,13 @@ void ReplicationStateMachine::on_complete_replace_member(const std::string& task
     home_object_->on_pg_complete_replace_member(repl_dev()->group_id(), task_id, member_out, member_in, tid);
 }
 
+void ReplicationStateMachine::on_clean_replace_member_task(const std::string& task_id,
+                                                           const homestore::replica_member_info& member_out,
+                                                           const homestore::replica_member_info& member_in,
+                                                           trace_id_t tid) {
+    home_object_->on_pg_clean_replace_member_task(repl_dev()->group_id(), task_id, member_out, member_in, tid);
+}
+
 void ReplicationStateMachine::on_destroy(const homestore::group_id_t& group_id) {
     auto PG_ID = home_object_->get_pg_id_with_group_id(group_id);
     if (!PG_ID.has_value()) {

--- a/src/lib/homestore_backend/replication_state_machine.hpp
+++ b/src/lib/homestore_backend/replication_state_machine.hpp
@@ -183,6 +183,10 @@ public:
     void on_complete_replace_member(const std::string& task_id, const homestore::replica_member_info& member_out,
                                     const homestore::replica_member_info& member_in, trace_id_t tid = 0) override;
 
+    /// @brief Called when clean replace member task (rollback)
+    void on_clean_replace_member_task(const std::string& task_id, const homestore::replica_member_info& member_out,
+                                      const homestore::replica_member_info& member_in, trace_id_t tid = 0) override;
+
     /// @brief Called when the replica is being destroyed by nuraft;
     void on_destroy(const homestore::group_id_t& group_id) override;
 


### PR DESCRIPTION
- Implement on_pg_clean_replace_member_task callback which actually rollback the membership change
- Add a reconcile_membership API which is used to correct the existing inconsistency problem.

Rely on https://github.com/eBay/HomeStore/pull/856