### PR TITLE
refine index_kv constructor

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "4.1.8"
+    version = "4.1.9"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/blob_route.hpp
+++ b/src/lib/blob_route.hpp
@@ -20,7 +20,7 @@ struct BlobRoute {
     sisl::blob to_blob() const { return sisl::blob{uintptr_cast(const_cast< BlobRoute* >(this)), sizeof(*this)}; }
 };
 
-// used for gc to quickly identify all the blob in the move_to chunk
+// used for gc to quickly identify all the blobs in move_to_chunk
 struct BlobRouteByChunk {
     // homestore::chunk_num_t == uint16_t
     uint16_t chunk{0};

--- a/src/lib/homestore_backend/index_kv.hpp
+++ b/src/lib/homestore_backend/index_kv.hpp
@@ -16,7 +16,7 @@ private:
 public:
     BlobRouteKey() = default;
     BlobRouteKey(const BlobRoute key) : key_(key) {}
-    BlobRouteKey(const BlobRouteKey& other) : BlobRouteKey(other.serialize(), true) {}
+    BlobRouteKey(const BlobRouteKey& other) : homestore::BtreeKey(), key_(other.key_) {}
     BlobRouteKey(const homestore::BtreeKey& other) : BlobRouteKey(other.serialize(), true) {}
     BlobRouteKey(const sisl::blob& b, bool copy) :
             homestore::BtreeKey(), key_{*(r_cast< const BlobRoute* >(b.cbytes()))} {}
@@ -58,7 +58,7 @@ private:
 public:
     BlobRouteByChunkKey() = default;
     BlobRouteByChunkKey(const BlobRouteByChunk key) : key_(key) {}
-    BlobRouteByChunkKey(const BlobRouteByChunkKey& other) : BlobRouteByChunkKey(other.serialize(), true) {}
+    BlobRouteByChunkKey(const BlobRouteByChunkKey& other) : homestore::BtreeKey(), key_(other.key_) {}
     BlobRouteByChunkKey(const homestore::BtreeKey& other) : BlobRouteByChunkKey(other.serialize(), true) {}
     BlobRouteByChunkKey(const sisl::blob& b, bool copy) :
             homestore::BtreeKey(), key_{*(r_cast< const BlobRouteByChunk* >(b.cbytes()))} {}
@@ -99,7 +99,7 @@ class BlobRouteValue : public homestore::BtreeValue {
 public:
     BlobRouteValue() = default;
     BlobRouteValue(const homestore::MultiBlkId& pbas) : pbas_(pbas) {}
-    BlobRouteValue(const BlobRouteValue& other) : homestore::BtreeValue() { pbas_ = other.pbas_; };
+    BlobRouteValue(const BlobRouteValue& other) : homestore::BtreeValue(), pbas_(other.pbas_) {};
     BlobRouteValue(const sisl::blob& b, bool copy) : homestore::BtreeValue() { deserialize(b, copy); }
     BlobRouteValue(const homestore::BtreeValue& other) : BlobRouteValue(other.serialize(), true) {}
     virtual ~BlobRouteValue() = default;


### PR DESCRIPTION
this PR refines index_kv constructor, which will not do reinterpret_cast to bypass the issue in #403 