### PR TITLE
SDSTOR-21763 Fix GC job status update for multi-PG scenarios

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "4.1.6"
+    version = "4.1.7"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/hs_http_manager.cpp
+++ b/src/lib/homestore_backend/hs_http_manager.cpp
@@ -608,23 +608,26 @@ void HttpManager::trigger_gc(const Pistache::Rest::Request& request, Pistache::H
         std::vector< pg_id_t > pg_ids;
         ho_.get_pg_ids(pg_ids);
 
-        if (pg_ids.empty()) {
-            result["error"] = "no PG found";
-            response.send(Pistache::Http::Code::Not_Found, result.dump());
-            return;
-        }
-
         const auto job_id = generate_job_id();
         result["job_id"] = job_id;
-        result["message"] = "GC triggered for all chunks, pls query job status using gc_job_status API";
-        // return response before starting the GC so that we don't block the client.
-        response.send(Pistache::Http::Code::Accepted, result.dump());
 
         auto job_info = std::make_shared< GCJobInfo >(job_id);
         {
             std::lock_guard lock(gc_job_mutex_);
             gc_jobs_map_.set(job_id, job_info);
         }
+
+        if (pg_ids.empty()) {
+            LOGINFO("GC job {} no PGs found, marking as completed", job_id);
+            job_info->status = GCJobStatus::COMPLETED;
+            result["message"] = "No PGs found, GC completed";
+            response.send(Pistache::Http::Code::Ok, result.dump());
+            return;
+        }
+
+        result["message"] = "GC triggered for all chunks, pls query job status using gc_job_status API";
+        // return response before starting the GC so that we don't block the client.
+        response.send(Pistache::Http::Code::Accepted, result.dump());
 
         LOGINFO("GC job {} will process {} PGs", job_id, pg_ids.size());
         LOGINFO("GC job {} stopping GC scan timer", job_id);

--- a/src/lib/homestore_backend/hs_http_manager.cpp
+++ b/src/lib/homestore_backend/hs_http_manager.cpp
@@ -596,13 +596,28 @@ void HttpManager::trigger_gc(const Pistache::Rest::Request& request, Pistache::H
         gc_mgr->stop_gc_scan_timer();
 
         // we block here until all gc tasks for the pg are done
-        trigger_gc_for_pg(pg_id, job_id);
+        trigger_gc_for_pg(pg_id, job_id)
+            .thenValue([job_info](auto&&) {
+                job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
+                LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_info->job_id,
+                        job_info->total_chunks, job_info->success_count, job_info->failed_count);
+            })
+            .get();
 
         LOGINFO("GC job {} restarting GC scan timer", job_id);
         gc_mgr->start_gc_scan_timer();
     } else {
         LOGINFO("Received trigger_gc request for all chunks");
         nlohmann::json result;
+        std::vector< pg_id_t > pg_ids;
+        ho_.get_pg_ids(pg_ids);
+
+        if (pg_ids.empty()) {
+            result["error"] = "no PG found";
+            response.send(Pistache::Http::Code::Not_Found, result.dump());
+            return;
+        }
+
         const auto job_id = generate_job_id();
         result["job_id"] = job_id;
         result["message"] = "GC triggered for all chunks, pls query job status using gc_job_status API";
@@ -615,16 +630,24 @@ void HttpManager::trigger_gc(const Pistache::Rest::Request& request, Pistache::H
             gc_jobs_map_.set(job_id, job_info);
         }
 
-        std::vector< pg_id_t > pg_ids;
-        ho_.get_pg_ids(pg_ids);
         LOGINFO("GC job {} will process {} PGs", job_id, pg_ids.size());
         LOGINFO("GC job {} stopping GC scan timer", job_id);
         gc_mgr->stop_gc_scan_timer();
 
-        // we block here until all gc tasks for the pg are done
+        // we block here until all gc tasks for all pgs are done
+        std::vector< folly::Future< folly::Unit > > pg_futures;
         for (const auto& pg_id : pg_ids) {
-            trigger_gc_for_pg(pg_id, job_id);
+            pg_futures.push_back(trigger_gc_for_pg(pg_id, job_id));
         }
+
+        // Set job status after all PGs are processed
+        folly::collectAllUnsafe(pg_futures)
+            .thenValue([job_info](auto&&) {
+                job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
+                LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_info->job_id,
+                        job_info->total_chunks, job_info->success_count, job_info->failed_count);
+            })
+            .get();
 
         LOGINFO("GC job {} restarting GC scan timer", job_id);
         gc_mgr->start_gc_scan_timer();
@@ -703,7 +726,7 @@ void HttpManager::get_gc_job_status(const Pistache::Rest::Request& request, Pist
     response.send(Pistache::Http::Code::Ok, result.dump());
 }
 
-void HttpManager::trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id) {
+folly::Future< folly::Unit > HttpManager::trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id) {
     auto hs_pg = const_cast< HSHomeObject::HS_PG* >(ho_.get_hs_pg(pg_id));
     RELEASE_ASSERT(hs_pg, "HS PG {} not found during GC job {}", pg_id, job_id);
 
@@ -742,7 +765,7 @@ void HttpManager::trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id) {
                  (priority == task_priority::emergent) ? "emergent" : "normal");
     }
 
-    folly::collectAllUnsafe(gc_task_futures)
+    return folly::collectAllUnsafe(gc_task_futures)
         .thenValue([job_info](auto&& results) {
             for (auto const& ok : results) {
                 RELEASE_ASSERT(ok.hasValue(), "we never throw any exception when copying data");
@@ -753,8 +776,8 @@ void HttpManager::trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id) {
                 }
             }
         })
-        .thenValue([this, pg_id, job_info, gc_mgr](auto&& rets) {
-            LOGINFO("All GC tasks have been processed");
+        .thenValue([this, pg_id, job_info](auto&& rets) {
+            LOGINFO("All GC tasks for PG {} have been processed", pg_id);
             const auto& job_id = job_info->job_id;
 
             auto hs_pg = const_cast< HSHomeObject::HS_PG* >(ho_.get_hs_pg(pg_id));
@@ -762,12 +785,7 @@ void HttpManager::trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id) {
             // Resume accepting new requests for this pg
             hs_pg->repl_dev_->resume_accepting_reqs();
             LOGINFO("GC job {} resumed accepting requests for PG {}", job_id, pg_id);
-
-            job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
-            LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_id, job_info->total_chunks,
-                    job_info->success_count, job_info->failed_count);
-        })
-        .get();
+        });
 }
 
 #ifdef _PRERELEASE

--- a/src/lib/homestore_backend/hs_http_manager.cpp
+++ b/src/lib/homestore_backend/hs_http_manager.cpp
@@ -595,17 +595,13 @@ void HttpManager::trigger_gc(const Pistache::Rest::Request& request, Pistache::H
         LOGINFO("GC job {} stopping GC scan timer", job_id);
         gc_mgr->stop_gc_scan_timer();
 
-        // we block here until all gc tasks for the pg are done
-        trigger_gc_for_pg(pg_id, job_id)
-            .thenValue([job_info](auto&&) {
-                job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
-                LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_info->job_id,
-                        job_info->total_chunks, job_info->success_count, job_info->failed_count);
-            })
-            .get();
-
-        LOGINFO("GC job {} restarting GC scan timer", job_id);
-        gc_mgr->start_gc_scan_timer();
+        trigger_gc_for_pg(pg_id, job_id).thenValue([job_info, gc_mgr, job_id](auto&&) {
+            job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
+            LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_info->job_id, job_info->total_chunks,
+                    job_info->success_count, job_info->failed_count);
+            LOGINFO("GC job {} restarting GC scan timer", job_id);
+            gc_mgr->start_gc_scan_timer();
+        });
     } else {
         LOGINFO("Received trigger_gc request for all chunks");
         nlohmann::json result;
@@ -634,23 +630,19 @@ void HttpManager::trigger_gc(const Pistache::Rest::Request& request, Pistache::H
         LOGINFO("GC job {} stopping GC scan timer", job_id);
         gc_mgr->stop_gc_scan_timer();
 
-        // we block here until all gc tasks for all pgs are done
         std::vector< folly::Future< folly::Unit > > pg_futures;
         for (const auto& pg_id : pg_ids) {
             pg_futures.push_back(trigger_gc_for_pg(pg_id, job_id));
         }
 
         // Set job status after all PGs are processed
-        folly::collectAllUnsafe(pg_futures)
-            .thenValue([job_info](auto&&) {
-                job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
-                LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_info->job_id,
-                        job_info->total_chunks, job_info->success_count, job_info->failed_count);
-            })
-            .get();
-
-        LOGINFO("GC job {} restarting GC scan timer", job_id);
-        gc_mgr->start_gc_scan_timer();
+        folly::collectAllUnsafe(pg_futures).thenValue([job_info, gc_mgr, job_id](auto&&) {
+            job_info->status = job_info->failed_count ? GCJobStatus::FAILED : GCJobStatus::COMPLETED;
+            LOGINFO("GC job {} completed: total={}, success={}, failed={}", job_info->job_id, job_info->total_chunks,
+                    job_info->success_count, job_info->failed_count);
+            LOGINFO("GC job {} restarting GC scan timer", job_id);
+            gc_mgr->start_gc_scan_timer();
+        });
     }
 }
 

--- a/src/lib/homestore_backend/hs_http_manager.hpp
+++ b/src/lib/homestore_backend/hs_http_manager.hpp
@@ -48,7 +48,7 @@ private:
     void exit_pg(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void trigger_gc(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
     void get_gc_job_status(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
-    void trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id);
+    folly::Future< folly::Unit > trigger_gc_for_pg(uint16_t pg_id, const std::string& job_id);
     void get_job_status(const std::string& job_id, nlohmann::json& result);
 
 #ifdef _PRERELEASE


### PR DESCRIPTION
Refactor trigger_gc_for_pg to return folly::Future and defer job status updates to callers. Previously, when triggering GC for all PGs, the job status was incorrectly set to COMPLETED after the first PG finished. Now the job status is only set to COMPLETED after all PGs have completed their GC operations.

Changes:
 - trigger_gc_for_pg now returns folly::Future<folly::Unit>
 - Removed set_job_status parameter and internal status updates
 - Callers use thenValue to set job status after completion
 - Single PG GC: sets status after that PG completes
 - Multi PG GC: collects all futures and sets status after all complete