### PR TITLE
Update branch for version check workflow

### DIFF
--- a/.github/workflows/version_change_check.yml
+++ b/.github/workflows/version_change_check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
     branches:
-      - main
+      - stable/v4.x
 
 jobs:
   check-file:

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "4.1.9"
+    version = "4.1.10"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"


### PR DESCRIPTION
version check workflow was not updated to stable/v4.x (current default branch)