### PR TITLE
BR: Fix GC blkID race causing stale CORRUPTED data

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "4.1.14"
+    version = "4.1.15"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/hs_blob_manager.cpp
+++ b/src/lib/homestore_backend/hs_blob_manager.cpp
@@ -365,7 +365,7 @@ BlobManager::AsyncResult< Blob > HSHomeObject::_get_blob_data(const shared< home
                 return folly::makeUnexpected(BlobError(BlobErrorCode::READ_FAILED));
             }
 
-            auto verify_result = do_verify_blob(read_buf.cbytes(), shard_id, 0 /* no blob_id check */);
+            auto verify_result = do_verify_blob(read_buf.cbytes(), shard_id, blob_id);
             if (!verify_result.hasValue()) { return folly::makeUnexpected(verify_result.error()); }
             std::string user_key = std::move(verify_result.value());
 

--- a/src/lib/homestore_backend/hs_homeobject.hpp
+++ b/src/lib/homestore_backend/hs_homeobject.hpp
@@ -564,6 +564,8 @@ public:
         PG* get_pg_metadata() const;
         objId expected_next_obj_id() const;
         BlobManager::AsyncResult< blob_read_result > load_blob_data(const BlobInfo& blob_info);
+        BlobManager::AsyncResult< blob_read_result > load_blob_data_with_blkid(shard_id_t shard_id, blob_id_t blob_id,
+                                                                               homestore::MultiBlkId blkid);
         bool prefetch_blobs_snapshot_data();
         void pack_resync_message(sisl::io_blob_safe& dest_blob, SyncMessageType type);
 

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -252,7 +252,7 @@ HSHomeObject::PGBlobIterator::load_blob_data_with_blkid(shard_id_t shard_id, blo
                 return folly::makeUnexpected(BlobError(BlobErrorCode::READ_FAILED));
             }
 
-            if (home_obj_.verify_blob(read_buf.cbytes(), shard_id, 0 /* no blob_id check */)) {
+            if (home_obj_.verify_blob(read_buf.cbytes(), shard_id, blob_id)) {
                 LOGD("Blob get success: shardID=0x{:x}, pg={}, shard=0x{:x}, blob_id={}", shard_id,
                      (shard_id >> homeobject::shard_width), (shard_id & homeobject::shard_mask), blob_id);
                 return blob_read_result(blob_id, std::move(read_buf), ResyncBlobState::NORMAL);

--- a/src/lib/homestore_backend/pg_blob_iterator.cpp
+++ b/src/lib/homestore_backend/pg_blob_iterator.cpp
@@ -227,10 +227,13 @@ bool HSHomeObject::PGBlobIterator::create_shard_snapshot_data(sisl::io_blob_safe
 
 typedef HSHomeObject::PGBlobIterator::blob_read_result blob_read_result;
 BlobManager::AsyncResult< blob_read_result > HSHomeObject::PGBlobIterator::load_blob_data(const BlobInfo& blob_info) {
-    auto shard_id = blob_info.shard_id;
-    auto blob_id = blob_info.blob_id;
-    auto blkid = blob_info.pbas;
-    auto const total_size = blob_info.pbas.blk_count() * repl_dev_->get_blk_size();
+    return load_blob_data_with_blkid(blob_info.shard_id, blob_info.blob_id, blob_info.pbas);
+}
+
+BlobManager::AsyncResult< blob_read_result >
+HSHomeObject::PGBlobIterator::load_blob_data_with_blkid(shard_id_t shard_id, blob_id_t blob_id,
+                                                        homestore::MultiBlkId blkid) {
+    auto const total_size = blkid.blk_count() * repl_dev_->get_blk_size();
     sisl::io_blob_safe read_buf{total_size, io_align};
 
     sisl::sg_list sgs;
@@ -240,7 +243,7 @@ BlobManager::AsyncResult< blob_read_result > HSHomeObject::PGBlobIterator::load_
     LOGD("Blob get request: shardID=0x{:x}, pg={}, shard=0x{:x}, blob_id={}, blkid={}", shard_id,
          (shard_id >> homeobject::shard_width), (shard_id & homeobject::shard_mask), blob_id, blkid.to_string());
     return repl_dev_->async_read(blkid, sgs, total_size)
-        .thenValue([this, blob_id, shard_id, read_buf = std::move(read_buf)](
+        .thenValue([this, blob_id, shard_id, blkid, read_buf = std::move(read_buf)](
                        auto&& result) mutable -> BlobManager::AsyncResult< blob_read_result > {
             if (result) {
                 LOGE("Failed to get blob, shardID=0x{:x}, pg={}, shard=0x{:x}, blob_id={}, err={}", shard_id,
@@ -249,16 +252,39 @@ BlobManager::AsyncResult< blob_read_result > HSHomeObject::PGBlobIterator::load_
                 return folly::makeUnexpected(BlobError(BlobErrorCode::READ_FAILED));
             }
 
-            if (!home_obj_.verify_blob(read_buf.cbytes(), shard_id, 0 /* no blob_id check */)) {
-                // The metrics for corrupted blob is handled on the follower side.
+            if (home_obj_.verify_blob(read_buf.cbytes(), shard_id, 0 /* no blob_id check */)) {
+                LOGD("Blob get success: shardID=0x{:x}, pg={}, shard=0x{:x}, blob_id={}", shard_id,
+                     (shard_id >> homeobject::shard_width), (shard_id & homeobject::shard_mask), blob_id);
+                return blob_read_result(blob_id, std::move(read_buf), ResyncBlobState::NORMAL);
+            }
+
+            // verify_blob failed — check if GC moved the blob to a new blkid since cur_blob_list_ was captured.
+            auto index_table = home_obj_.get_index_table(pg_id);
+            if (!index_table) {
+                LOGE("PG not found when checking index for GC race, pg={}, blob={}", pg_id, blob_id);
+                return folly::makeUnexpected(BlobError(BlobErrorCode::READ_FAILED));
+            }
+            auto current_pbas = home_obj_.get_blob_from_index_table(index_table, shard_id, blob_id);
+            if (!current_pbas) {
+                // Blob was deleted concurrently after generate_shard_blob_list captured its pbas.
+                // Do not send stale bytes as CORRUPTED — signal READ_FAILED so the snapshot restarts
+                // and generate_shard_blob_list picks up tombstone_pbas, skipping the blob cleanly.
+                LOGI("Blob deleted during GC race, shard=0x{:x}, blob={}, triggering snapshot restart", shard_id,
+                     blob_id);
+                return folly::makeUnexpected(BlobError(BlobErrorCode::READ_FAILED));
+            }
+            if (current_pbas.value() == blkid) {
+                // blkid unchanged — genuinely corrupted data at this location.
+                // Metrics for corrupted blobs are handled on the follower side.
                 LOGE("Blob verification failed, shardID=0x{:x}, pg={}, shard=0x{:x}, blob_id={}", shard_id,
                      (shard_id >> homeobject::shard_width), (shard_id & homeobject::shard_mask), blob_id);
                 return blob_read_result(blob_id, std::move(read_buf), ResyncBlobState::CORRUPTED);
             }
 
-            LOGD("Blob get success: shardID=0x{:x}, pg={}, shard=0x{:x}, blob_id={}", shard_id,
-                 (shard_id >> homeobject::shard_width), (shard_id & homeobject::shard_mask), blob_id);
-            return blob_read_result(blob_id, std::move(read_buf), ResyncBlobState::NORMAL);
+            // GC moved the blob — retry with the updated blkid. Folly flattens the returned future.
+            LOGI("GC moved blob detected during snapshot: shard=0x{:x}, blob={}, old_blkid={}, new_blkid={}", shard_id,
+                 blob_id, blkid.to_string(), current_pbas.value().to_string());
+            return load_blob_data_with_blkid(shard_id, blob_id, current_pbas.value());
         });
 }
 

--- a/src/lib/homestore_backend/snapshot_receive_handler.cpp
+++ b/src/lib/homestore_backend/snapshot_receive_handler.cpp
@@ -223,7 +223,7 @@ int HSHomeObject::SnapshotReceiveHandler::process_blobs_snapshot_data(ResyncBlob
         // Check integrity of normal blobs
         if (blob->state() != static_cast< uint8_t >(ResyncBlobState::CORRUPTED)) {
             // Verify full blob (includes validation, shard_id check, and hash verification)
-            if (!home_obj_.verify_blob(blob_data, ctx_->shard_cursor, 0 /* no blob_id check */)) {
+            if (!home_obj_.verify_blob(blob_data, ctx_->shard_cursor, blob->blob_id())) {
                 LOGE("Blob verification failed for blob_id={}", blob->blob_id());
                 std::unique_lock< std::shared_mutex > lock(ctx_->progress_lock);
                 ctx_->progress.error_count++;

--- a/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
+++ b/src/lib/homestore_backend/tests/homeobj_misc_tests.cpp
@@ -194,6 +194,127 @@ TEST_F(HomeObjectFixture, PGBlobIterator) {
     ASSERT_TRUE(pg_iter->update_cursor(objId(LAST_OBJ_ID)));
 }
 
+// Simulates a GC race where blob blkID changes between generate_shard_blob_list and load_blob_data.
+// Injects a cross-shard pbas into cur_blob_list_ so verify_blob fails (shard_id mismatch in blob header).
+// The retry inside load_blob_data_with_blkid re-reads the index, finds the updated pbas, and re-reads
+// the blob successfully. create_blobs_snapshot_data should return true with the blob marked NORMAL.
+TEST_F(HomeObjectFixture, PGBlobIteratorGCMoveDetection) {
+    constexpr pg_id_t pg_id{1};
+    create_pg(pg_id);
+    auto shard_1_info = create_shard(pg_id, 64 * Mi, "shard1");
+    auto shard_2_info = create_shard(pg_id, 64 * Mi, "shard2");
+    auto shard_1_id = shard_1_info.id;
+    auto shard_2_id = shard_2_info.id;
+
+    // blob_0 -> shard_1, blob_1 -> shard_2
+    std::map< pg_id_t, std::vector< shard_id_t > > pg_shard_map{{pg_id, {shard_1_id, shard_2_id}}};
+    std::map< pg_id_t, blob_id_t > pg_blob_id{{pg_id, 0}};
+    put_blobs(pg_shard_map, 1 /* num_blobs_per_shard */, pg_blob_id);
+
+    auto pg = _obj_inst->get_hs_pg(pg_id);
+    ASSERT_TRUE(pg != nullptr);
+
+    auto snp_lsn = pg->shards_.back()->info.lsn;
+    auto pg_iter = std::make_shared< HSHomeObject::PGBlobIterator >(*_obj_inst, pg->pg_info_.replica_set_uuid, snp_lsn);
+    ASSERT_EQ(pg_iter->shard_list_.size(), 2u);
+    pg_iter->max_batch_size_ = 1 * Mi;
+
+    auto shard_1_seq_num = HSHomeObject::get_sequence_num_from_shard_id(shard_1_id);
+    ASSERT_TRUE(pg_iter->update_cursor(objId(shard_1_seq_num, 0)));
+    ASSERT_TRUE(pg_iter->generate_shard_blob_list());
+    ASSERT_EQ(pg_iter->cur_blob_list_.size(), 1u);
+
+    // Save the correct pbas for blob_0 in shard_1
+    auto correct_pbas = pg_iter->cur_blob_list_[0].pbas;
+
+    // Get shard_2's blob_1 pbas — its blob header has shard_2_id, so verify_blob against shard_1_id will fail.
+    auto index_table = _obj_inst->get_index_table(pg_id);
+    auto shard_2_blob_pbas = _obj_inst->get_blob_from_index_table(index_table, shard_2_id, 1 /* blob_id */);
+    ASSERT_TRUE(shard_2_blob_pbas.hasValue());
+    ASSERT_NE(shard_2_blob_pbas.value(), correct_pbas);
+
+    // Inject stale pbas (simulating GC moved blob_0 to a new location already reflected in the
+    // index table, but cur_blob_list_ still holds the old blkID).
+    // The index still points to correct_pbas, so load_blob_data_with_blkid will:
+    //   1. Read from shard_2_blob_pbas → verify_blob fails (shard_id mismatch)
+    //   2. Re-read index → finds correct_pbas != shard_2_blob_pbas → retry
+    //   3. Read from correct_pbas → verify_blob passes → NORMAL
+    pg_iter->cur_blob_list_[0].pbas = shard_2_blob_pbas.value();
+
+    sisl::io_blob_safe shard_meta_blob;
+    ASSERT_TRUE(pg_iter->create_shard_snapshot_data(shard_meta_blob));
+
+    objId batch_1_oid(shard_1_seq_num, 1);
+    ASSERT_TRUE(pg_iter->update_cursor(batch_1_oid));
+
+    sisl::io_blob_safe data_blob;
+    ASSERT_TRUE(pg_iter->create_blobs_snapshot_data(data_blob));
+
+    auto* msg_hdr = r_cast< SyncMessageHeader* >(data_blob.bytes());
+    ASSERT_EQ(msg_hdr->msg_type, SyncMessageType::SHARD_BATCH);
+    auto blob_msg = GetSizePrefixedResyncBlobDataBatch(data_blob.cbytes() + sizeof(SyncMessageHeader));
+    ASSERT_EQ(blob_msg->blob_list()->size(), 1u);
+    EXPECT_EQ(blob_msg->blob_list()->Get(0)->blob_id(), 0u);
+    EXPECT_EQ(blob_msg->blob_list()->Get(0)->state(), static_cast< uint8_t >(ResyncBlobState::NORMAL));
+    EXPECT_TRUE(blob_msg->is_last_batch());
+
+    pg_iter->stop();
+}
+
+// Simulates the race where a blob is tombstoned (deleted) after generate_shard_blob_list captured its pbas.
+// verify_blob fails on the stale read; the index lookup returns UNKNOWN_BLOB (tombstone) so !current_pbas
+// is true — treated as unchanged — and the blob is returned as CORRUPTED.
+TEST_F(HomeObjectFixture, PGBlobIteratorGCTombstoneDetection) {
+    constexpr pg_id_t pg_id{1};
+    create_pg(pg_id);
+    auto shard_1_info = create_shard(pg_id, 64 * Mi, "shard1");
+    auto shard_2_info = create_shard(pg_id, 64 * Mi, "shard2");
+    auto shard_1_id = shard_1_info.id;
+    auto shard_2_id = shard_2_info.id;
+
+    // blob_0 -> shard_1, blob_1 -> shard_2
+    std::map< pg_id_t, std::vector< shard_id_t > > pg_shard_map{{pg_id, {shard_1_id, shard_2_id}}};
+    std::map< pg_id_t, blob_id_t > pg_blob_id{{pg_id, 0}};
+    put_blobs(pg_shard_map, 1 /* num_blobs_per_shard */, pg_blob_id);
+
+    auto pg = _obj_inst->get_hs_pg(pg_id);
+    ASSERT_TRUE(pg != nullptr);
+
+    auto snp_lsn = pg->shards_.back()->info.lsn;
+    auto pg_iter = std::make_shared< HSHomeObject::PGBlobIterator >(*_obj_inst, pg->pg_info_.replica_set_uuid, snp_lsn);
+    pg_iter->max_batch_size_ = 1 * Mi;
+
+    auto shard_1_seq_num = HSHomeObject::get_sequence_num_from_shard_id(shard_1_id);
+    ASSERT_TRUE(pg_iter->update_cursor(objId(shard_1_seq_num, 0)));
+    ASSERT_TRUE(pg_iter->generate_shard_blob_list());
+    ASSERT_EQ(pg_iter->cur_blob_list_.size(), 1u);
+
+    // Get shard_2's blob_1 pbas to inject as a stale blkid for blob_0 in shard_1.
+    auto index_table = _obj_inst->get_index_table(pg_id);
+    auto shard_2_blob_pbas = _obj_inst->get_blob_from_index_table(index_table, shard_2_id, 1 /* blob_id */);
+    ASSERT_TRUE(shard_2_blob_pbas.hasValue());
+
+    // Inject stale pbas and tombstone blob_0 so the index lookup returns UNKNOWN_BLOB.
+    // Flow: read from shard_2's location → verify_blob fails (shard_id mismatch) →
+    //       re-read index for (shard_1_id, blob_0) → UNKNOWN_BLOB (tombstoned) →
+    //       !current_pbas is true → return CORRUPTED.
+    pg_iter->cur_blob_list_[0].pbas = shard_2_blob_pbas.value();
+    del_blob(pg_id, shard_1_id, 0 /* blob_id */);
+
+    sisl::io_blob_safe shard_meta_blob;
+    ASSERT_TRUE(pg_iter->create_shard_snapshot_data(shard_meta_blob));
+
+    objId batch_1_oid(shard_1_seq_num, 1);
+    ASSERT_TRUE(pg_iter->update_cursor(batch_1_oid));
+
+    // READ_FAILED is returned so the snapshot restarts; generate_shard_blob_list will then pick up
+    // tombstone_pbas for blob_0 and skip it cleanly on the next attempt.
+    sisl::io_blob_safe data_blob;
+    ASSERT_FALSE(pg_iter->create_blobs_snapshot_data(data_blob));
+
+    pg_iter->stop();
+}
+
 TEST_F(HomeObjectFixture, SnapshotReceiveHandler) {
     constexpr uint64_t snp_lsn = 1;
     constexpr uint64_t num_shards_per_pg = 3;


### PR DESCRIPTION
During PG snapshot, PGBlobIterator captures blob pbas in cur_blob_list_. If GC runs before the actual reads, all blobs in the shard are moved to new blkIDs, causing verify_blob to fail and incorrectly marking blobs as CORRUPTED with invalid stale data.

Fix: ~on verify_blob failure, re-check the index table. If pbas changed, signal STALE_BLKID, refresh the entire shard's blob list, and trigger NuRaft resend.~
Add an infinite recursive loop to load_blob_data to re-read the latest index and reload if blkID changes to ensure we get the correct data.