### PR TITLE
Fix nuraft_mesg missing from homestore component requires in package_info

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -122,7 +122,7 @@ class HomeObjectConan(ConanFile):
              keep_path=True)
 
     def package_info(self):
-        self.cpp_info.components["homestore"].requires = ["homestore::homestore", "iomgr::iomgr", "sisl::sisl"]
+        self.cpp_info.components["homestore"].requires = ["homestore::homestore", "iomgr::iomgr", "sisl::sisl", "nuraft_mesg::nuraft_mesg"]
         self.cpp_info.components["memory"].requires = ["sisl::sisl"]
         self.cpp_info.components["homeobject"].requires = ["homestore"]
 


### PR DESCRIPTION
nuraft_mesg is a direct dependency used by the homestore backend (replication_state_machine), but was not referenced in any component's requires in package_info(). Conan 2 requires all direct dependencies to appear in at least one component's requires when components are defined.