### PR TITLE
Reduce default BR batch size to 64MiB

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "4.1.23"
+    version = "4.1.24"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/hs_backend_config.fbs
+++ b/src/lib/homestore_backend/hs_backend_config.fbs
@@ -14,7 +14,7 @@ table HSBackendSettings {
     backend_timer_us: uint64 = 60000000 (hotswap);
 
     // Maximum size of a snapshot batch
-    max_snapshot_batch_size_mb: uint64 = 128 (hotswap);
+    max_snapshot_batch_size_mb: uint64 = 64 (hotswap);
 
     //Snapshot blob load retry count
     snapshot_blob_load_retry: uint8 = 3 (hotswap);


### PR DESCRIPTION
128MiB batches can stall & timeout during periods of network slowness.