### PR TITLE
SDSTOR-23030 fix backward compatibility

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.60.0"
 
 class HomeObjectConan(ConanFile):
     name = "homeobject"
-    version = "4.2.3"
+    version = "4.2.4"
 
     homepage = "https://github.com/eBay/HomeObject"
     description = "Blob Store built on HomeStore"

--- a/src/lib/homestore_backend/replication_state_machine.cpp
+++ b/src/lib/homestore_backend/replication_state_machine.cpp
@@ -212,21 +212,14 @@ ReplicationStateMachine::get_blk_alloc_hints(sisl::blob const& header, uint32_t 
     switch (msg_header->msg_type) {
     case ReplicationMessageType::CREATE_SHARD_MSG:
     case ReplicationMessageType::SEAL_SHARD_MSG: {
-        if (data_size == 0) {
-            // New log-only format: should not reach here, but handle gracefully.
-            LOGW("get_blk_alloc_hints called for log-only shard message type={}, shard={}, pg={}", msg_header->msg_type,
-                 msg_header->shard_id, msg_header->pg_id);
-            return homestore::blk_alloc_hints{};
-        } else {
-            // Old format: shard message carried shard header/footer data blocks. Return committed_blk_id
-            // so HomeStore skips block allocation and data write. Shard on_commit will ignore pbas.
-            homestore::blk_alloc_hints hints;
-            hints.committed_blk_id = HSHomeObject::tombstone_pbas;
-            LOGW("get_blk_alloc_hints called for old shard message type={}, shard={}, pg={}, return committed_blk hint "
-                 "to skip blk allocation",
-                 msg_header->msg_type, msg_header->shard_id, msg_header->pg_id);
-            return hints;
-        }
+        // Old format: shard message carried shard header/footer data blocks. Return committed_blk_id
+        // so HomeStore skips block allocation and data write. Shard on_commit will ignore pbas.
+        homestore::blk_alloc_hints hints;
+        hints.committed_blk_id = HSHomeObject::tombstone_pbas;
+        LOGW("get_blk_alloc_hints called for old shard message type={}, shard={}, pg={}, return committed_blk hint "
+             "to skip blk allocation",
+             msg_header->msg_type, msg_header->shard_id, msg_header->pg_id);
+        return hints;
     }
 
     case ReplicationMessageType::PUT_BLOB_MSG:


### PR DESCRIPTION
## Background

Commit `4b25833` made `CREATE_SHARD_MSG` and `SEAL_SHARD_MSG` log-only: the leader now calls
`async_alloc_write` with empty data (`HS_DATA_INLINED`), so no data blocks are allocated for
shard creation. Correspondingly, `HeapChunkSelector::select_chunk` was changed to
`RELEASE_ASSERT(false, ...)` since it should never be called for shard messages in the new
design.

During a rolling upgrade, a **pre-upgrade SM** (old code) still creates shards in the old
format:
it allocates one block, serializes the `BlkId` into the Raft journal value, and stores the
entry
as `HS_DATA_LINKED` (`value_size = sizeof(MultiBlkId) > 0`, `blk_count = 1`). A
**post-upgrade SM** (new code) must handle these old-format entries when acting as a
follower.

## Root Cause

The crash is a **two-phase cascade** caused by `localize_journal_entry_prepare` overwriting
the
Raft journal value with the follower's localized blkid.

### Phase 1 — Post-upgrade follower processes old-format entry from pre-upgrade leader

Pre-upgrade leader log:
HS_DATA_LINKED | value_size > 0 | blkid = {X, nblks=1, Y}

Post-upgrade follower, localize_journal_entry_prepare:
entry_blkid.blk_count() = 1  →  data_size = 1 × blk_size = 4096
→ get_blk_alloc_hints(data_size=4096)
    data_size > 0 branch → returns tombstone_pbas  ✓
→ alloc_local_blks: m_local_blkids = [tombstone_pbas{0,0,0}]  (blk_count = 0)
→ memcpy(journal_value, local_blkid.serialize(), sizeof(MultiBlkId))
    overwrites journal value with tombstone bytes (all zeros)

The post-upgrade follower's local logstore now holds:

HS_DATA_LINKED | value_size = sizeof(MultiBlkId) > 0 | value = tombstone bytes (blk_count =
0)

`code` and `value_size` are unchanged, but the value bytes now encode a zero blkid.

### Phase 2 — Any subsequent post-upgrade follower receives the already-corrupted entry

Once the corrupted entry exists in any SM's local log, any new post-upgrade follower that
catches
up from that SM receives:

HS_DATA_LINKED | value_size > 0 | value = tombstone bytes

localize_journal_entry_prepare:
entry_blkid.deserialize(...)  →  tombstone_pbas, blk_count() = 0
data_size = 0 × blk_size = 0

Condition: (code == HS_DATA_LINKED) && (value_size > 0)  → TRUE (both hold)
→ takes HS_DATA_LINKED branch
→ applier_create_req(op_code = HS_DATA_LINKED, data_size = 0)
→ init(): has_linked_data() = true, data_size = 0
    → alloc_local_blks(listener, data_size = 0)
    → get_blk_alloc_hints(data_size = 0)
        data_size == 0 branch → returns empty blk_alloc_hints{}   ← BUG
→ committed_blk_id.has_value() = false
    → falls through to data_service().alloc_blks()
    → VirtualDev::alloc_blks() → HeapChunkSelector::select_chunk()
    → RELEASE_ASSERT(false, "create shard is log only...") → SIGABRT